### PR TITLE
Fixing bugs for error/success messages when adding items to collections

### DIFF
--- a/vre/static/vre/main.js
+++ b/vre/static/vre/main.js
@@ -366,8 +366,7 @@ var VRECollectionView = LazyTemplateView.extend({
             'collections': selected_collections,
         };
         records_and_collections.save(additions, {
-            success: _.bind( function(model, response, options) {
-                console.log(options);
+            success: _.bind( function(model, response) {
                 var feedbackString = '';
                 $.each(response, function(key, value) {
                     feedbackString = feedbackString.concat('Added ', value, ' record(s) to ', key, ". ");
@@ -378,8 +377,7 @@ var VRECollectionView = LazyTemplateView.extend({
                     }, 2000);
                 });
             }, this),
-            error: _.bind(function(model, response, options) {
-                console.log(options);
+            error: _.bind(function(model, response) {
                 var feedbackString = response.responseJSON.error;
                 this.$('.alert-warning').html(feedbackString).show(500, function() {
                     setTimeout(function() {


### PR DESCRIPTION
I detected two problems with the error and success messages:
- in RecordDetailView, the VRECollectionView set the associated model to undefined after adding it to the database, causing a faulty error message when repeatedly adding the same model.
- the success and error callbacks of the AdditionsToCollections model's .save method had global context, so all alert elements were found instead of only those associated with the element from which the .save method was called. This could be circumvented with _.bind.