### PR TITLE
Feature/search annotations

### DIFF
--- a/vre/api.py
+++ b/vre/api.py
@@ -147,9 +147,7 @@ class SearchViewSet(ViewSetMixin, APIView):
                 new_result = RecordSerializer(ann.record).data
                 if not new_result in result_list:
                     result_list.append(new_result)
-            print(result_list)
             result_info = {'total_results': len(result_list), 'result_list': result_list}
-            print(len(result_list))
         return Response(result_info)
 
 


### PR DESCRIPTION
The previous merge still contained a bug: records whose annotations contained the search term were added to the result_list, even if the result_list already contained them. I know added an extra check for this.