### PR TITLE
Feature/select all

### DIFF
--- a/vre/static/vre/main.js
+++ b/vre/static/vre/main.js
@@ -241,14 +241,14 @@ var SearchResults = Records.extend({
 var VRECollection = Backbone.Model.extend({
     getRecords: function() {
         if (!this.records) {
-            this.records = new Records();
-            this.records.query({
+            var records = this.records = new Records();
+            records.query({
                 params: {collection__id: this.id},
-            }).then(function(collection) {
-                collection.trigger('complete');
+            }).then(function() {
+                records.trigger('complete');
             });
         }
-        return this.records;
+        return records;
     },
 });
 
@@ -528,6 +528,7 @@ var RecordListView = LazyTemplateView.extend({
         'submit': function(event) {
             this.vreCollectionsSelect.submitForm(event);
         },
+        'click #more-records': 'loadMore',
     },
     initialize: function(options) {
         this.items = [];
@@ -567,6 +568,9 @@ var RecordListView = LazyTemplateView.extend({
             this.$tbody.append(item.render().el);
         }
         return this;
+    },
+    loadMore: function(event) {
+        searchView.nextSearch(event);
     },
     showSelectAll: function() {
         var selectAllView = this.selectAllView = new SelectAllView();
@@ -928,7 +932,6 @@ $(function() {
         JST[$el.prop('id')] = Handlebars.compile($el.html(), {compat: true});
     });
     $('#result_detail').modal({show: false});
-    $('#more-records').click(searchView.nextSearch.bind(searchView));
     // We fetch the collections and ensure that we have them before we handle
     // the route, because VRERouter.showCollection depends on them being
     // available. This is something we can definitely improve upon.

--- a/vre/templates/vre/client_templates.html
+++ b/vre/templates/vre/client_templates.html
@@ -51,6 +51,7 @@
 
 <script type="text/x-handlebars-template" id="record-list">
     <h4 id="search-feedback"></h4>
+    <a href="#" id="more-records">Load more records</a>
     <table class="table table-striped">
         <tbody></tbody>
     </table>

--- a/vre/templates/vre/hpb.html
+++ b/vre/templates/vre/hpb.html
@@ -8,6 +8,5 @@
         The HPB Database (previously called the Hand Press Book Database) is a steadily growing collection of files of catalogue records from major European and North American research libraries covering items of European printing of the hand-press period (c.1455-c.1830) integrated into one file. This makes it possible for information to be retrieved in one single search across all files. As the digitisation of collections in contributing libraries progresses, more and more catalogue records point to digital presentations of the early printed books.
     </div>
 </div>
-<a href="#" id="more-records">Load more records</a>
 {% include "vre/item_detail.html" %}
 {% endblock content %}


### PR DESCRIPTION
Implements #70.

A checkbox with "select all" label is shown at the top of the records list, if and only if the list is complete (so not if only a subset of results of a HPB search is shown). If checked, all records are checked. If unchecked, all records are unchecked. If a single record is checked or unchecked, the "select all" checkbox responds, too.

Works if checking individual records and pressing "load more" is interleaved, although the "check all" box doesn't always respond if you check all records manually in this scenario. I suggest to consider this a minor cosmetic issue that we can leave for later.