### PR TITLE
problem fixed, response as first variable in alert callbacks

### DIFF
--- a/vre/static/vre/main.js
+++ b/vre/static/vre/main.js
@@ -388,14 +388,14 @@ var VRECollectionView = LazyTemplateView.extend({
             this.showError.bind(this),
         );
     },
-    showSuccess: function(model, response) {
+    showSuccess: function(response) {
         var feedbackString = '';
-        $.each(model, function(key, value) {
+        $.each(response, function(key, value) {
             feedbackString = feedbackString.concat('Added ', value, ' record(s) to ', key, ". ");
         });
         this.showAlert('success', feedbackString);
     },
-    showError: function(model, response) {
+    showError: function(response) {
         this.showAlert('warning', response.responseJSON.error);
     },
     showAlert: function(level, message) {


### PR DESCRIPTION
The error was caused by the fact that the first variable passed into the callbacks is the response that contains the success / error message.