### PR TITLE
remove backports-zoneinfo from requirements

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,8 +6,6 @@
 #
 asgiref==3.5.2
     # via django
-backports-zoneinfo==0.2.1
-    # via django
 beautifulsoup4==4.11.1
     # via -r requirements.in
 certifi==2022.9.24


### PR DESCRIPTION
What it says in the title. This was needed to install from `requirements.txt` with python 3.8, at least for me.