### PR TITLE
Inject edpop-explorer datafiles into Docker container via ignored directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ db*
 .\#*
 *~
 \#*\#
+
+# edpop-explorer datafiles
+/backend/edpopx-data/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
             - ./backend:/usr/src/app/backend
             - bapyca:/usr/src/app/backend/__pycache__
             - ./frontend/vre:/usr/src/app/frontend/vre
+            - ./backend/edpopx-data:/root/.local/share/edpop-explorer
         ports:
             - 127.0.0.1:8000:8000
     frontend:


### PR DESCRIPTION
This small change enabled me to use the USTC data file together with `docker-compose`.