### PR TITLE
Some catalogue view improvements

### DIFF
--- a/backend/catalogs/graphs.py
+++ b/backend/catalogs/graphs.py
@@ -24,7 +24,7 @@ def _hash(input_str: str) -> str:
 def _get_activated_readers() -> list[type[Reader]]:
     """Get a list of all activated readers."""
     # Currently simply return all registered readers in settings.py, but
-    # we may want to dynamically register and deregister readers in the 
+    # we may want to dynamically register and deregister readers in the
     # future (e.g., to deactivate when a server is failing).
     return settings.CATALOG_READERS
 
@@ -41,7 +41,7 @@ def refresh_readers() -> None:
     for unit tests."""
     global READERS_BY_URIREF
     READERS_BY_URIREF = _get_reader_dict()
-    
+
 
 READERS_BY_URIREF = _get_reader_dict()
 
@@ -117,7 +117,11 @@ class SearchGraphBuilder:
         """Perform the fetch. This method is supposed to be called just
         once. After fetching, the requested records (and only those)
         are available in the ``records`` attribute, and ``get_result_graph()``
-        can be called to create the accompanying graph."""
+        can be called to create the accompanying graph.
+
+        During the fetch, a ReaderError may be raised that can be the
+        result of an unavailable service or a problem with the query.
+        The message of this exception may be passed to the end user."""
         # Reader objects are cached for a limited period of time because
         # certain queries may be expensive.
         # To identify caches, the `generate_identifier()` method of a reader
@@ -160,7 +164,7 @@ class SearchGraphBuilder:
         remove_from_triplestore(results)
         save_to_triplestore(content_graph)
         return content_graph
-    
+
     def _get_collection_graph(self) -> Graph:
         """Return a graph with an ActivityStreams Collection containing
         references to the requested records in the right order."""

--- a/frontend/vre/catalog/catalog.search.view.js
+++ b/frontend/vre/catalog/catalog.search.view.js
@@ -5,7 +5,7 @@ import { SearchView } from '../search/search.view.js';
 import { RecordListManagingView } from '../record/record.list.managing.view.js';
 import collectionSearchTemplate from './collection.search.view.mustache';
 
-export var CollectionSearchView = CompositeView.extend({
+export var CatalogSearchView = CompositeView.extend({
     template: collectionSearchTemplate,
     subviews: [
         {view: 'searchView', selector: '.page-header'},

--- a/frontend/vre/catalog/collection.search.view.js
+++ b/frontend/vre/catalog/collection.search.view.js
@@ -19,6 +19,7 @@ export var CollectionSearchView = CompositeView.extend({
         });
         this.recordsManager = new RecordListManagingView({
             collection: this.collection,
+            type: "catalog",
         });
         this.render();
     },

--- a/frontend/vre/collection/browse-collection.view.js
+++ b/frontend/vre/collection/browse-collection.view.js
@@ -27,7 +27,8 @@ export var BrowseCollectionView = CompositeView.extend({
             collection: this.collection,
         });
         this.recordsManager = new RecordListManagingView({
-            collection: this.collection
+            collection: this.collection,
+            type: "collection",
         });
         this.model.getRecords(this.collection);
         var editor = new EditSummaryView({model: this.model});

--- a/frontend/vre/collection/select-collection.view.js
+++ b/frontend/vre/collection/select-collection.view.js
@@ -59,6 +59,10 @@ export var SelectCollectionView = AggregateView.extend({
     createCollection: function(event) {
         event.preventDefault();
         var project = vreChannel.request('projects:current');
+        if (!project) {
+            alert("Please select a project before adding a collection.");
+            return;
+        }
         var input = this.$('.dropdown-menu form input');
         var name = input.val();
         this.collection.create({

--- a/frontend/vre/main.js
+++ b/frontend/vre/main.js
@@ -10,7 +10,7 @@ window.DEBUGGING = true;
 import './record/record.opening.aspect';
 import { vreChannel } from './radio';
 import { VRECollections } from './collection/collection.model';
-import { CollectionSearchView } from './catalog/collection.search.view';
+import { CatalogSearchView } from './catalog/catalog.search.view';
 import { BrowseCollectionView } from './collection/browse-collection.view';
 
 import { SelectCollectionView } from './collection/select-collection.view';
@@ -72,7 +72,7 @@ navigationState.on({
 // currently selected collection.
 catalogs.on({
     focus: catalog => navigationState.set(
-        'browser', new CollectionSearchView({model: catalog})),
+        'browser', new CatalogSearchView({model: catalog})),
 });
 
 function showCollection(vreCollection) {

--- a/frontend/vre/main.js
+++ b/frontend/vre/main.js
@@ -9,7 +9,6 @@ window.DEBUGGING = true;
 
 import './record/record.opening.aspect';
 import { vreChannel } from './radio';
-import { BlankRecordButtonView } from './record/blank.record.button.view';
 import { VRECollections } from './collection/collection.model';
 import { CollectionSearchView } from './catalog/collection.search.view';
 import { BrowseCollectionView } from './collection/browse-collection.view';
@@ -28,7 +27,6 @@ import { WelcomeView } from './utils/welcome.view.js';
 GlobalVariables.myCollections = new VRECollections();
 
 // Regular global variables, only visible in this module.
-var blankRecordButton = new BlankRecordButtonView();
 var catalogs = new Catalogs([], {comparator: 'name'});
 var catalogDropdown = new SelectCatalogView({
     collection: catalogs
@@ -113,7 +111,6 @@ function startRouting() {
     $('.nav').first().append(
         catalogDropdown.el,
         collectionDropdown.el,
-        blankRecordButton.el,
     );
     Backbone.history.start({
         pushState: true,

--- a/frontend/vre/record/record.list.managing.view.js
+++ b/frontend/vre/record/record.list.managing.view.js
@@ -3,6 +3,9 @@ import { VRECollectionView } from '../collection/collection.view';
 import { GlobalVariables } from '../globals/variables';
 import recordListManagingTemplate from './record.list.managing.view.mustache';
 import {RecordListView} from "./record.list.view";
+import {vreChannel} from "../radio";
+import {Record} from "./record.model";
+import _ from "lodash";
 
 export var RecordListManagingView = CompositeView.extend({
     tagName: 'form',
@@ -23,9 +26,11 @@ export var RecordListManagingView = CompositeView.extend({
         'click .500-more-records': 'load500More',
         'click .download-xlsx': 'downloadXLSX',
         'click .download-csv': 'downloadCSV',
+        'click .create-blank': 'createBlank',
     },
 
     initialize: function(options) {
+        _.assign(this, _.pick(options, ['type']));
         this.vreCollectionsSelect = new VRECollectionView({
             collection: GlobalVariables.myCollections
         }).render();
@@ -35,7 +40,8 @@ export var RecordListManagingView = CompositeView.extend({
     },
 
     renderContainer: function() {
-        this.$el.html(this.template({}));
+        const addBlankRecord = this.type === "collection";
+        this.$el.html(this.template({addBlankRecord}));
         return this;
     },
 
@@ -53,5 +59,11 @@ export var RecordListManagingView = CompositeView.extend({
 
     downloadCSV: function() {
         this.recordListView.downloadCSV();
+    },
+
+    createBlank: function() {
+        vreChannel.trigger('displayRecord', new Record({
+            content: {},
+        }));
     },
 });

--- a/frontend/vre/record/record.list.managing.view.mustache
+++ b/frontend/vre/record/record.list.managing.view.mustache
@@ -4,4 +4,7 @@
     <li><a href="#" class="500-more-records">Load 500 more records</a></li>
     <li><a href="#" class="download-xlsx">Download XLSX</a></li>
     <li><a href="#" class="download-csv">Download CSV</a></li>
+{{#addBlankRecord}}
+    <li><a href="#" class="create-blank">Create blank record</a></li>
+{{/addBlankRecord}}
 </ul>

--- a/frontend/vre/record/record.list.view.js
+++ b/frontend/vre/record/record.list.view.js
@@ -46,6 +46,9 @@ export var RecordListView = Backbone.View.extend({
     },
 
     updateTable: function() {
+        if (this.collection.length === 0) {
+            return;
+        }
         const data = this.collection.toTabularData();
         if (this.table === null) {
             this.createTable(data);

--- a/frontend/vre/search/failed.search.message.mustache
+++ b/frontend/vre/search/failed.search.message.mustache
@@ -1,2 +1,1 @@
-Search failed: {{responseJSON}}<br>
-Status code: {{status}}.
+Search failed. Status code: {{status}}.

--- a/frontend/vre/search/failed.search.message.mustache
+++ b/frontend/vre/search/failed.search.message.mustache
@@ -1,1 +1,2 @@
-Search failed. Status code: {{status}}.
+Search failed (code {{statusCode}}, {{statusText}}).
+{{#message}}<br>Reason: {{message}}{{/message}}

--- a/frontend/vre/search/search.view.js
+++ b/frontend/vre/search/search.view.js
@@ -47,9 +47,16 @@ export var SearchView = CompositeView.extend({
         return searchPromise;
     },
     alertError: function(collection, response, options) {
+        const statusCode = response.status;
+        const statusText = response.statusText;
+        const message = response.responseJSON["http://www.w3.org/2011/http#reasonPhrase"];
         this.alert = new AlertView({
             level: 'warning',
-            message: failedSearchTemplate(response),
+            message: failedSearchTemplate({
+                statusCode,
+                statusText,
+                message,
+            }),
         });
         this.alert.once('removed', this.deleteAlert, this);
         this.placeSubviews();

--- a/frontend/vre/search/search.view.js
+++ b/frontend/vre/search/search.view.js
@@ -83,7 +83,11 @@ export var SearchView = CompositeView.extend({
         } else {
             $('#more-records').show();
         }
-        $('#search-feedback').text("Showing " + this.collection.length + " of " + this.collection.totalResults + " results");
+        if (this.collection.length > 0) {
+            $('#search-feedback').text("Showing " + this.collection.length + " of " + this.collection.totalResults + " results");
+        } else {
+            $('#search-feedback').text("No results found");
+        }
     },
     fill: function(fillText) {
         this.$('#query-input').val(fillText);

--- a/frontend/vre/search/search.view.js
+++ b/frontend/vre/search/search.view.js
@@ -51,7 +51,10 @@ export var SearchView = CompositeView.extend({
     alertError: function(collection, response, options) {
         const statusCode = response.status;
         const statusText = response.statusText;
-        const message = response.responseJSON["http://www.w3.org/2011/http#reasonPhrase"];
+        let message;
+        if (response.responseJSON) {
+            message = response.responseJSON["http://www.w3.org/2011/http#reasonPhrase"];
+        }
         this.alert = new AlertView({
             level: 'warning',
             message: failedSearchTemplate({

--- a/frontend/vre/search/search.view.js
+++ b/frontend/vre/search/search.view.js
@@ -24,10 +24,12 @@ export var SearchView = CompositeView.extend({
     },
     showPending: function() {
         this.$('form button').first().text('Searching...');
+        $("body").css("cursor", "progress");
         return this;
     },
     showIdle: function() {
         this.$('form button').first().text('Search');
+        $("body").css("cursor", "default");
         return this;
     },
     submitSearch: function(startRecord, number=50) {


### PR DESCRIPTION
A few improvements to the catalogue view based on a conversation with Jeroen:

* Better displayment of errors that occur in the explorer: the messages of `ReaderError` are shown to the user
* Do not show tables when there are no results. This also shows the problem that when no results were shown, next queries were resulting in a table with rows but without columns
* Move the create blank record button, which was always visible but not always relevant, to the record list manager view (as per Jeroen's request)
* A small refactoring: rename `CollectionSearchView` to `CatalogSearchView`