### PR TITLE
Only show fields that are relevant to a specific record class

### DIFF
--- a/backend/catalogs/api.py
+++ b/backend/catalogs/api.py
@@ -54,6 +54,7 @@ class CatalogsView(RDFView):
     """Return a graph containing all activated catalogs."""
     renderer_classes = (JsonLdRenderer,)
     json_ld_context = {
+        "edpoprec": str(EDPOPREC),
         "schema": "https://schema.org/",
         "name": "schema:name",
         "description": "schema:description",

--- a/frontend/vre/catalog/catalog.search.view.js
+++ b/frontend/vre/catalog/catalog.search.view.js
@@ -4,6 +4,7 @@ import { SearchResults } from '../search/search.model.js';
 import { SearchView } from '../search/search.view.js';
 import { RecordListManagingView } from '../record/record.list.managing.view.js';
 import collectionSearchTemplate from './collection.search.view.mustache';
+import {readerTypeToRecordClass} from "../utils/record-ontology";
 
 export var CatalogSearchView = CompositeView.extend({
     template: collectionSearchTemplate,
@@ -13,6 +14,7 @@ export var CatalogSearchView = CompositeView.extend({
     ],
     initialize: function() {
         this.collection = this.collection || new SearchResults;
+        this.recordClass = readerTypeToRecordClass[this.model.get('@type')];
         this.searchView = new SearchView({
             model: this.model,
             collection: this.collection,
@@ -20,6 +22,7 @@ export var CatalogSearchView = CompositeView.extend({
         this.recordsManager = new RecordListManagingView({
             collection: this.collection,
             type: "catalog",
+            recordClass: this.recordClass,
         });
         this.render();
     },

--- a/frontend/vre/record/record.detail.view.mustache
+++ b/frontend/vre/record/record.detail.view.mustache
@@ -24,7 +24,7 @@
 
             <ul class="inline-list">
                 {{#databaseId}}<li>ID in database: {{databaseId}}</li>{{/databaseId}}
-                {{#publicURL}}<li><a href="{{publicURL}}" target="_blank">Show record in original database</a></i></li>{{/publicURL}}
+                {{#publicURL}}<li><a href="{{publicURL}}" target="_blank">Show record in original database</a></li>{{/publicURL}}
             </ul>
         </div>
         <div class="modal-footer" style="justify-content: space-between">

--- a/frontend/vre/record/record.detail.view.mustache
+++ b/frontend/vre/record/record.detail.view.mustache
@@ -24,7 +24,7 @@
 
             <ul class="inline-list">
                 {{#databaseId}}<li>ID in database: {{databaseId}}</li>{{/databaseId}}
-                {{#publicURL}}<li><a href="{{publicURL}}" target="_blank">Show record in original database</a></li>{{/publicURL}}
+                {{#publicURL}}<li><a href="{{publicURL}}" target="_blank">Show record in original database</a></i></li>{{/publicURL}}
             </ul>
         </div>
         <div class="modal-footer" style="justify-content: space-between">

--- a/frontend/vre/record/record.list.managing.view.js
+++ b/frontend/vre/record/record.list.managing.view.js
@@ -10,6 +10,16 @@ import _ from "lodash";
 export var RecordListManagingView = CompositeView.extend({
     tagName: 'form',
     template: recordListManagingTemplate,
+    /**
+     * The kind of record list ("collection" or "catalog")
+     * @type {?string}
+     */
+    type: null,
+    /**
+     * The record class (BIBLIOGRAPHICAL or BIOGRAPHICAL)
+     * @type {?string}
+     */
+    recordClass: null,
 
     subviews: [
         {view: 'vreCollectionsSelect', method: 'prepend'},
@@ -30,11 +40,14 @@ export var RecordListManagingView = CompositeView.extend({
     },
 
     initialize: function(options) {
-        _.assign(this, _.pick(options, ['type']));
+        _.assign(this, _.pick(options, ['type', 'recordClass']));
         this.vreCollectionsSelect = new VRECollectionView({
             collection: GlobalVariables.myCollections
         }).render();
-        this.recordListView = new RecordListView({collection: this.collection});
+        this.recordListView = new RecordListView({
+            collection: this.collection,
+            recordClass: this.recordClass
+        });
         this.render();
         this.recordListView.render();
     },

--- a/frontend/vre/record/record.list.view.js
+++ b/frontend/vre/record/record.list.view.js
@@ -29,7 +29,7 @@ export var RecordListView = Backbone.View.extend({
             height: "calc(100vh - 360px)", // set height to table approximately to what is left of viewport height
             data: initialData,
             autoColumns: true,
-            autoColumnsDefinitions: adjustDefinitions,
+            autoColumnsDefinitions: (autodetected) => {return adjustDefinitions(autodetected, this.recordClass)},
             layout: "fitColumns",
             rowHeader: {
                 width: 50,

--- a/frontend/vre/record/record.list.view.js
+++ b/frontend/vre/record/record.list.view.js
@@ -47,6 +47,7 @@ export var RecordListView = Backbone.View.extend({
 
     updateTable: function() {
         if (this.collection.length === 0) {
+            this.removeTable();
             return;
         }
         const data = this.collection.toTabularData();
@@ -54,6 +55,13 @@ export var RecordListView = Backbone.View.extend({
             this.createTable(data);
         } else {
             this.table.replaceData(data);
+        }
+    },
+
+    removeTable: function() {
+        if (this.table) {
+            this.table.destroy();
+            this.table = null;
         }
     },
 

--- a/frontend/vre/record/record.list.view.js
+++ b/frontend/vre/record/record.list.view.js
@@ -2,6 +2,7 @@ import Backbone from "backbone";
 import {vreChannel} from "../radio";
 import Tabulator from "tabulator";
 import {adjustDefinitions} from "../utils/tabulator-utils";
+import _ from "lodash";
 
 export var RecordListView = Backbone.View.extend({
     id: "record-list",
@@ -10,8 +11,14 @@ export var RecordListView = Backbone.View.extend({
      * @type {Tabulator}
      */
     table: null,
+    /**
+     * The record class (BIBLIOGRAPHICAL or BIOGRAPHICAL)
+     * @type {?string}
+     */
+    recordClass: null,
 
     initialize: function(options) {
+        _.assign(this, _.pick(options, ['recordClass']));
         this.collection.on("sync", () => {
             this.updateTable();
         });

--- a/frontend/vre/utils/record-ontology.js
+++ b/frontend/vre/utils/record-ontology.js
@@ -17,6 +17,14 @@ export var PropertyList = JsonLdNestedCollection.extend({
 export var properties = new PropertyList();
 properties.fetch();
 
+export const BIBLIOGRAPHICAL = "edpoprec:BibliographicalRecord";
+export const BIOGRAPHICAL = "edpoprec:BiographicalRecord";
+
+export const readerTypeToRecordClass = {
+    "edpoprec:BibliographicalCatalog": BIBLIOGRAPHICAL,
+    "edpoprec:BiographicalCatalog": BIOGRAPHICAL,
+}
+
 /**
  * Regular expression matching `'edpoprec:Record'`,
  * `'edpoprec:BiographicalRecord'` and `'edpoprec:BibliographicalRecord'`. The

--- a/frontend/vre/utils/record-ontology.js
+++ b/frontend/vre/utils/record-ontology.js
@@ -97,9 +97,12 @@ function domainFitsQualification(target, domain) {
  */
 function appliesToSuitableDomains(criterion, property, onlyFields=true) {
     var domain = property.get('rdfs:domain');
-    var range = property.get('rdfs:range')?.['@id'];
+    var range = property.get('rdfs:range');
+    var rangeId;
+    if (range)
+        rangeId = range['@id'];
     if (!domain) return false;
-    if (onlyFields && !fieldList.includes(range)) return false;
+    if (onlyFields && !fieldList.includes(rangeId)) return false;
     if (!_.isArray(domain)) domain = [domain];
     return _.find(domain, criterion);
 }

--- a/frontend/vre/utils/record-ontology.js
+++ b/frontend/vre/utils/record-ontology.js
@@ -26,6 +26,19 @@ export const readerTypeToRecordClass = {
 }
 
 /**
+ * A list of all field types according to the record ontology.
+ * This is hardcoded for now because there is no trivial way to infer this
+ * by reasoning from the ontology JSON-LD file.
+ * @type {string[]}
+ */
+export const fieldList = [
+    'edpoprec:Field',
+    'edpoprec:DatingField',
+    'edpoprec:LanguageField',
+    'edpoprec:LocationField',
+];
+
+/**
  * Regular expression matching `'edpoprec:Record'`,
  * `'edpoprec:BiographicalRecord'` and `'edpoprec:BibliographicalRecord'`. The
  * first capturing group contains the full qualification before `'Record'` (if
@@ -77,11 +90,16 @@ function domainFitsQualification(target, domain) {
  * @param {ldObjectPredicate} criterion - Predicate against which the domains of the property should be matched.
  * @param {Backbone.Model} property - Model-wrapped JSON-LD representation of an
  * RDF property.
+ * @param {boolean} onlyFields - if `true', only accept properties that have edpoprec:Field or a subclass
+ * as their range.
  * @returns {boolean} `true` if at least one domain of the property matches the criterion, `false` otherwise.
  */
-function appliesToSuitableDomains(criterion, property) {
+function appliesToSuitableDomains(criterion, property, onlyFields=true) {
+    console.log(criterion, property);
     var domain = property.get('rdfs:domain');
+    var range = property.get('rdfs:range')?.['@id'];
     if (!domain) return false;
+    if (onlyFields && !fieldList.includes(range)) return false;
     if (!_.isArray(domain)) domain = [domain];
     return _.find(domain, criterion);
 }
@@ -110,16 +128,3 @@ export var bioProperties = new FilteredCollection(properties, appliesToBiographi
 export var biblioProperties = new FilteredCollection(properties, appliesToBibliographs);
 
 export var biblioAndBioProperties = new FilteredCollection(properties, appliesToAnyDomain);
-
-/**
- * A list of all field types according to the record ontology.
- * This is hardcoded for now because there is no trivial way to infer this
- * by reasoning from the ontology JSON-LD file.
- * @type {string[]}
- */
-export const fieldList = [
-    'edpoprec:Field',
-    'edpoprec:DatingField',
-    'edpoprec:LanguageField',
-    'edpoprec:LocationField',
-];

--- a/frontend/vre/utils/record-ontology.js
+++ b/frontend/vre/utils/record-ontology.js
@@ -95,7 +95,6 @@ function domainFitsQualification(target, domain) {
  * @returns {boolean} `true` if at least one domain of the property matches the criterion, `false` otherwise.
  */
 function appliesToSuitableDomains(criterion, property, onlyFields=true) {
-    console.log(criterion, property);
     var domain = property.get('rdfs:domain');
     var range = property.get('rdfs:range')?.['@id'];
     if (!domain) return false;

--- a/frontend/vre/utils/record-ontology.js
+++ b/frontend/vre/utils/record-ontology.js
@@ -36,6 +36,7 @@ export const fieldList = [
     'edpoprec:DatingField',
     'edpoprec:LanguageField',
     'edpoprec:LocationField',
+    'edpoprec:ContributorField',
 ];
 
 /**

--- a/frontend/vre/utils/tabulator-utils.js
+++ b/frontend/vre/utils/tabulator-utils.js
@@ -1,7 +1,12 @@
 import _ from 'lodash';
 import {Model, Collection} from 'backbone';
 import {MappedCollection} from './mapped.collection.js';
-import {biblioAndBioProperties} from './record-ontology';
+import {
+    BIBLIOGRAPHICAL,
+    biblioProperties,
+    BIOGRAPHICAL,
+    bioProperties
+} from './record-ontology';
 import {getStringLiteral} from './jsonld.model';
 import {typeTranslation} from './generic-functions.js';
 import recordTypeIcon from '../record/record.type.icon.mustache';
@@ -136,28 +141,36 @@ function property2definition(property) {
  * method in order to extract the column definitions in the format that
  * Tabulator understands.
  */
-const standardColumns = new MappedCollection(
-    biblioAndBioProperties,
-    property2definition,
-    {model: ColumnDefinition, comparator: byPreference},
-);
-
-// `@type` is not a property, so we add it as a special case. This enables the
-// person/book icons at the left end of every row.
-standardColumns.unshift({
-    field: 'type',
-    title: 'Type',
-    visible: true,
-    headerContextMenu: columnChooseMenu,
-    formatter: cell => recordTypeIcon(typeTranslation(cell.getValue())),
-    hozAlign: 'right',
-    tooltip: (e, cell) => cell.getValue().slice(9, -6),
-    width: 48,
-    // The `_ucid` is an implementation detail of `MappedCollection`. It appears
-    // here because mapped collections are not really intended for non-mapped
-    // additions or other modifications.
-    _ucid: {},
-}, {convert: false});
+const standardColumns = Object.fromEntries([BIBLIOGRAPHICAL, BIOGRAPHICAL].map((recordClass) => {
+    let propertyList;
+    if (recordClass === BIBLIOGRAPHICAL) {
+        propertyList = biblioProperties;
+    } else if (recordClass === BIOGRAPHICAL) {
+        propertyList = bioProperties;
+    }
+    const columns = new MappedCollection(
+        propertyList,
+        property2definition,
+        {model: ColumnDefinition, comparator: byPreference},
+    );
+    // `@type` is not a property, so we add it as a special case. This enables the
+    // person/book icons at the left end of every row.
+    columns.unshift({
+        field: 'type',
+        title: 'Type',
+        visible: true,
+        headerContextMenu: columnChooseMenu,
+        formatter: cell => recordTypeIcon(typeTranslation(cell.getValue())),
+        hozAlign: 'right',
+        tooltip: (e, cell) => cell.getValue().slice(9, -6),
+        width: 48,
+        // The `_ucid` is an implementation detail of `MappedCollection`. It appears
+        // here because mapped collections are not really intended for non-mapped
+        // additions or other modifications.
+        _ucid: {},
+    }, {convert: false});
+    return [recordClass, columns];
+}));
 
 /**
  * Callback for Tabulator's `autoColumnsDefinitions`. It always returns all
@@ -165,9 +178,11 @@ standardColumns.unshift({
  * columns to determine which columns should be visible. Columns that are both
  * preferred and present in the data are visible, all other columns are
  * invisible.
+ * @param autodetected - list of automatically detected columns by Tabulator
+ * @param {string} recordClass - the value of BIBLIOGRAPHICAL or BIOGRAPHICAL
  */
-export function adjustDefinitions(autodetected) {
-    const customizedColumns = standardColumns.clone();
+export function adjustDefinitions(autodetected, recordClass) {
+    const customizedColumns = standardColumns[recordClass].clone();
     _.each(autodetected, autoColumn => {
         if (!(autoColumn.field in columnProperties)) return;
         const customColumn = customizedColumns.get(autoColumn.field);

--- a/frontend/vre/utils/tabulator-utils.js
+++ b/frontend/vre/utils/tabulator-utils.js
@@ -153,22 +153,6 @@ const standardColumns = Object.fromEntries([BIBLIOGRAPHICAL, BIOGRAPHICAL].map((
         property2definition,
         {model: ColumnDefinition, comparator: byPreference},
     );
-    // `@type` is not a property, so we add it as a special case. This enables the
-    // person/book icons at the left end of every row.
-    columns.unshift({
-        field: 'type',
-        title: 'Type',
-        visible: true,
-        headerContextMenu: columnChooseMenu,
-        formatter: cell => recordTypeIcon(typeTranslation(cell.getValue())),
-        hozAlign: 'right',
-        tooltip: (e, cell) => cell.getValue().slice(9, -6),
-        width: 48,
-        // The `_ucid` is an implementation detail of `MappedCollection`. It appears
-        // here because mapped collections are not really intended for non-mapped
-        // additions or other modifications.
-        _ucid: {},
-    }, {convert: false});
     return [recordClass, columns];
 }));
 


### PR DESCRIPTION
As we discussed with Jeroen, we will only support catalog results and collections with a single record class (biographical and bibliographical). This makes it possible to limit the columns of the table view to only include relevant fields.

In addition, the column definitions were including some additional record data such as 'id' and 'original data', but these are not fields and should not be shown in the table, so I filtered them out.

I have removed the column on the left indicating whether the record is a bibliographical or biographical record with a nice symbol as well, because it has no function anymore now. Fortunately, the symbol is still visible in the detail view.

This PR should be reviewed after #253 because I built it upon that branch.