### PR TITLE
URLEncode collection IRI when fetching its records

### DIFF
--- a/backend/collect/api.py
+++ b/backend/collect/api.py
@@ -1,3 +1,5 @@
+from urllib.parse import unquote
+
 from rest_framework import status
 from rest_framework.viewsets import ModelViewSet, ViewSetMixin
 from rest_framework.views import APIView, Request
@@ -81,7 +83,7 @@ class CollectionRecordsView(RDFView):
     }
 
     def get_graph(self, request: Request, collection: str, **kwargs) -> Graph:
-        collection_uri = URIRef(collection)
+        collection_uri = URIRef(unquote(collection))
 
         if not collection_exists(collection_uri):
             raise NotFound('Collection does not exist')

--- a/frontend/vre/collection/collection.model.js
+++ b/frontend/vre/collection/collection.model.js
@@ -10,7 +10,7 @@ export var VRECollection = APIModel.extend({
     getRecords: function() {
         if (this.records) return this.records;
         var records = this.records = new Records();
-        records.url = `/api/collection-records/${this.id}/`;
+        records.url = `/api/collection-records/${encodeURIComponent(this.id)}/`;
         records.fetch().then(function() {
             records.trigger('complete');
         });


### PR DESCRIPTION
Theoretically, this should fix #267. However, I deployed this to the acceptance server and it turns out that the request does not even reach the Django application. Apparently, either Apache or Gunicorn is stopping any request URL that contains %xx encoded components.

I will be submit a support ticket to System Team in order to get this resolved.