### PR TITLE
Add originating catalog info to detail page

### DIFF
--- a/backend/requirements.in
+++ b/backend/requirements.in
@@ -10,4 +10,4 @@ sruthi
 rdflib
 restframework-rdf>=1.2.0,<2
 dj-rest-auth
-edpop-explorer>=0.12.0
+edpop-explorer>=0.13.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -36,7 +36,7 @@ djangorestframework==3.15.2
     #   -r requirements.in
     #   dj-rest-auth
     #   restframework-rdf
-edpop-explorer==0.12.0
+edpop-explorer==0.13.0
     # via -r requirements.in
 flatten-dict==0.4.2
     # via sruthi

--- a/frontend/vre/catalog/catalog.model.js
+++ b/frontend/vre/catalog/catalog.model.js
@@ -5,6 +5,9 @@ import {JsonLdCollection, JsonLdModel} from "../utils/jsonld.model";
  * Representation of a single catalogue.
  */
 export var Catalog = JsonLdModel.extend({
+    getName: function() {
+        return this.get("name");
+    }
 });
 
 /**

--- a/frontend/vre/catalog/catalog.model.js
+++ b/frontend/vre/catalog/catalog.model.js
@@ -5,6 +5,7 @@ import {JsonLdCollection, JsonLdModel} from "../utils/jsonld.model";
  * Representation of a single catalogue.
  */
 export var Catalog = JsonLdModel.extend({
+    idAttribute: '@id',
     getName: function() {
         return this.get("name");
     }

--- a/frontend/vre/digitization/digitization.view.mustache
+++ b/frontend/vre/digitization/digitization.view.mustache
@@ -11,7 +11,6 @@
             <p><a href="/mirador?manifest={{encodedManifestUrl}}" target="_blank">Show in Mirador</a></p>
         {{/iiif}}
         {{#externalUrl}}
-            <p class="card-text">{{ summaryText }}</p>
             <p class="card-text"><a href="{{externalUrl}}" target="_blank">Show digitization</a></p>
         {{/externalUrl}}
         {{#empty}}

--- a/frontend/vre/field/record.base.view.mustache
+++ b/frontend/vre/field/record.base.view.mustache
@@ -1,6 +1,6 @@
 <h5 class="mb-2">{{title}} <small>click any field to annotate</small></h5>
 <div>
-    <table class="table table-light table-hover"><tbody></tbody></table>
+    <table class="table table-sm table-light table-hover"><tbody></tbody></table>
     {{#editable}}
     <button type=button class="btn btn-default">New field</button>
     {{/editable}}

--- a/frontend/vre/main.js
+++ b/frontend/vre/main.js
@@ -112,9 +112,7 @@ vreChannel.reply('browsingType', () => navigationState.get('browsingType'));
 vreChannel.reply('browsingContext', () => navigationState.get('browsingContext'));
 
 // Make catalog information available via channel
-vreChannel.reply('getCatalog', (uri) => catalogs.findWhere({
-    "@id": uri
-}));
+vreChannel.reply('getCatalog', (uri) => catalogs.get(uri));
 
 // We want this code to run after two conditions are met:
 // 1. The DOM has fully loaded;

--- a/frontend/vre/main.js
+++ b/frontend/vre/main.js
@@ -111,6 +111,11 @@ vreChannel.reply('unsalientcollections', _.constant(unsalientCollections));
 vreChannel.reply('browsingType', () => navigationState.get('browsingType'));
 vreChannel.reply('browsingContext', () => navigationState.get('browsingContext'));
 
+// Make catalog information available via channel
+vreChannel.reply('getCatalog', (uri) => catalogs.findWhere({
+    "@id": uri
+}));
+
 // We want this code to run after two conditions are met:
 // 1. The DOM has fully loaded;
 // 2. the CSRF cookie has been obtained.

--- a/frontend/vre/record/record.about.view.js
+++ b/frontend/vre/record/record.about.view.js
@@ -1,0 +1,21 @@
+import Backbone from 'backbone';
+import recordAboutTemplate from './record.about.view.mustache';
+
+export var RecordAboutView = Backbone.View.extend({
+    tagName: 'div',
+    template: recordAboutTemplate,
+
+    initialize: function() {
+        this.render();
+    },
+
+    render: function() {
+        this.$el.html(this.template({
+            databaseId: this.model.get("edpoprec:identifier"),
+            publicURL: this.model.get("edpoprec:publicURL"),
+            fromCatalog: this.model.getCatalogName(),
+        }));
+        console.log(this.model.getCatalogName());
+        return this;
+    },
+});

--- a/frontend/vre/record/record.about.view.js
+++ b/frontend/vre/record/record.about.view.js
@@ -15,7 +15,6 @@ export var RecordAboutView = Backbone.View.extend({
             publicURL: this.model.get("edpoprec:publicURL"),
             fromCatalog: this.model.getCatalogName(),
         }));
-        console.log(this.model.getCatalogName());
         return this;
     },
 });

--- a/frontend/vre/record/record.about.view.mustache
+++ b/frontend/vre/record/record.about.view.mustache
@@ -1,0 +1,7 @@
+<h5 class="mb-2">About this record</h5>
+<div id="record-about">
+    <p>
+        {{#fromCatalog}}From <b>{{fromCatalog}}</b> ({{databaseId}}){{/fromCatalog}}
+    </p>
+    <p>{{#publicURL}}<a href="{{publicURL}}" target="_blank" class="btn btn-primary">Show record in original database</a>{{/publicURL}}</p>
+</div>

--- a/frontend/vre/record/record.detail.view.js
+++ b/frontend/vre/record/record.detail.view.js
@@ -13,6 +13,7 @@ import { GlobalVariables } from '../globals/variables';
 import recordDetailTemplate from './record.detail.view.mustache';
 import typeIconTemplate from './record.type.icon.mustache';
 import {DigitizationsView} from "../digitization/digitizations.view";
+import {RecordAboutView} from "./record.about.view";
 
 var renderOptions = {
     partials: {
@@ -41,6 +42,9 @@ export var RecordDetailView = CompositeView.extend({
         view: 'addSelect',
         selector: '.modal-footer'
     },{
+        view: 'aboutView',
+        selector: '#side-content',
+    },{
         view: 'digitizationsView',
         selector: '#side-content',
     }],
@@ -65,6 +69,9 @@ export var RecordDetailView = CompositeView.extend({
         this.digitizationsView = new DigitizationsView({
             collection: digitizations,
         });
+        this.aboutView = new RecordAboutView({
+            model: model,
+        }).render();
         this.annotationsView = new RecordAnnotationsView({
             collection: new FlatAnnotations(null, {record: model}),
         }).render();
@@ -84,8 +91,6 @@ export var RecordDetailView = CompositeView.extend({
             last: this.isLast,
             title: this.model.getMainDisplay(),
             uri: this.model.id,
-            databaseId: this.model.get("edpoprec:identifier"),
-            publicURL: this.model.get("edpoprec:publicURL"),
         }, typeTranslation(this.model)), renderOptions));
         return this;
     },

--- a/frontend/vre/record/record.detail.view.js
+++ b/frontend/vre/record/record.detail.view.js
@@ -71,7 +71,7 @@ export var RecordDetailView = CompositeView.extend({
         });
         this.aboutView = new RecordAboutView({
             model: model,
-        }).render();
+        });
         this.annotationsView = new RecordAnnotationsView({
             collection: new FlatAnnotations(null, {record: model}),
         }).render();

--- a/frontend/vre/record/record.detail.view.mustache
+++ b/frontend/vre/record/record.detail.view.mustache
@@ -29,10 +29,6 @@
             ></button>
         </div>
         <div class="modal-body">
-            <ul class="inline-list">
-                {{#databaseId}}<li>ID in database: {{databaseId}}</li>{{/databaseId}}
-                {{#publicURL}}<li><a href="{{publicURL}}" target="_blank">Show record in original database</a></li>{{/publicURL}}
-            </ul>
             <div class="container-fluid">
                 <div class="row">
                     <div class="col-md-9 px-0" id="main-content">

--- a/frontend/vre/record/record.model.js
+++ b/frontend/vre/record/record.model.js
@@ -47,7 +47,8 @@ export var Record = JsonLdModel.extend({
         return this.annotations;
     },
     getCatalogName: function() {
-        const catalogUri = this.get('edpoprec:fromCatalog')?.['@id'];
+        const catalog = this.get('edpoprec:fromCatalog');
+        const catalogUri = catalog && catalog['@id'];
         return vreChannel.request('getCatalog', catalogUri).getName();
     },
 });

--- a/frontend/vre/record/record.model.js
+++ b/frontend/vre/record/record.model.js
@@ -2,6 +2,7 @@ import { APIModel } from '../utils/api.model';
 import { Annotations } from '../annotation/annotation.model';
 import { JsonLdModel, JsonLdNestedCollection } from "../utils/jsonld.model";
 import { FlatFields } from "../field/field.model";
+import {vreChannel} from "../radio";
 
 export var Record = JsonLdModel.extend({
     urlRoot: '/api/records',
@@ -44,6 +45,10 @@ export var Record = JsonLdModel.extend({
             });
         }
         return this.annotations;
+    },
+    getCatalogName: function() {
+        const catalogUri = this.get('edpoprec:fromCatalog')?.['@id'];
+        return vreChannel.request('getCatalog', catalogUri).getName();
     },
 });
 


### PR DESCRIPTION
Show the name of the original catalog in the detail modal. For this I added an additional block on the right, which saves some vertical space.

I also made the fields table more compact to increase its chance of fitting on the screen...