### PR TITLE
Feature/comments

### DIFF
--- a/backend/accounts/utils.py
+++ b/backend/accounts/utils.py
@@ -1,0 +1,11 @@
+from django.contrib.auth.models import User
+from rdflib import URIRef
+
+from edpop.settings import RDF_NAMESPACE_ROOT
+
+RDF_ACCOUNTS_ROOT = RDF_NAMESPACE_ROOT + "accounts/"
+
+
+def user_to_uriref(user: User) -> URIRef:
+    assert not user.is_anonymous
+    return URIRef(RDF_NAMESPACE_ROOT + user.username)

--- a/backend/annotations/admin.py
+++ b/backend/annotations/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/backend/annotations/api.py
+++ b/backend/annotations/api.py
@@ -5,10 +5,10 @@ from rest_framework.views import Request
 from rest_framework.parsers import JSONParser
 from rest_framework.decorators import api_view, renderer_classes
 from rest_framework.response import Response
-from rdflib import URIRef, Graph, Literal, DCTERMS, RDFS
+from rdflib import URIRef, Graph, Literal, DCTERMS, RDFS, RDF
 import datetime
 
-from triplestore.constants import EDPOPREC, AS
+from triplestore.constants import EDPOPREC, AS, EDPOPCOL
 from rdf.views import RDFView
 from rdf.utils import graph_from_triples
 from rdf.renderers import TurtleRenderer, JsonLdRenderer
@@ -86,6 +86,7 @@ class AnnotationView(RDFView):
         as_published = Literal(datetime.date.today())
         dcterms_creator = user_to_uriref(request.user)
         triples = [
+            (subject_node, RDF.type, EDPOPCOL.Annotation),
             (subject_node, OA.hasTarget, oa_has_target),
             (subject_node, OA.motivatedBy, oa_motivated_by),
             (subject_node, OA.hasBody, oa_has_body),
@@ -117,7 +118,7 @@ class AnnotationEditView(RDFView):
         return Response(Graph())
 
     def put(self, request, **kwargs):
-        id_uriref = URIRef(request.data.get("@id"))
+        id_uriref = URIRef(kwargs.get("annotation"))
         oa_has_body = Literal(request.data.get("oa:hasBody"))
         as_updated = Literal(datetime.date.today())
         store = settings.RDFLIB_STORE

--- a/backend/annotations/api.py
+++ b/backend/annotations/api.py
@@ -34,6 +34,19 @@ where {{
 }}
 '''.format
 
+delete_annotation_update = '''
+delete {
+  graph ?annotations {
+    ?annotation ?p ?o.
+  }
+}
+where {
+  graph ?annotations {
+    ?annotation ?p ?o.
+  }
+}
+'''
+
 
 @api_view(['POST'])
 def add_annotation(request: Request) -> Response:
@@ -57,6 +70,18 @@ def add_annotation(request: Request) -> Response:
     # Get the existing graph from Blazegraph
     store = settings.RDFLIB_STORE
     store.addN(quads)
+    store.commit()
+    return Response({})
+
+
+@api_view(['PUT'])
+def delete_annotation(request: Request) -> Response:
+    id_uriref = URIRef(request.data.get("@id"))
+    store = settings.RDFLIB_STORE
+    store.update(delete_annotation_update, initBindings={
+        'annotations': ANNOTATION_GRAPH_IDENTIFIER,
+        'annotation': id_uriref,
+    })
     store.commit()
     return Response({})
 

--- a/backend/annotations/api.py
+++ b/backend/annotations/api.py
@@ -70,8 +70,7 @@ where {
 }
 '''
 
-
-class AddAnnotationView(RDFView):
+class AnnotationView(RDFView):
     parser_classes = (JSONParser,)
     renderer_classes = (JsonLdRenderer, TurtleRenderer)
     json_ld_context = JSON_LD_CONTEXT
@@ -102,22 +101,20 @@ class AddAnnotationView(RDFView):
         return Response(graph)
 
 
-@api_view(['PUT'])
-def delete_annotation(request: Request) -> Response:
-    id_uriref = URIRef(request.data.get("@id"))
-    store = settings.RDFLIB_STORE
-    store.update(delete_annotation_update, initBindings={
-        'annotations': ANNOTATION_GRAPH_IDENTIFIER,
-        'annotation': id_uriref,
-    })
-    store.commit()
-    return Response({})
-
-
-class UpdateAnnotationView(RDFView):
+class AnnotationEditView(RDFView):
     parser_classes = (JSONParser,)
     renderer_classes = (JsonLdRenderer, TurtleRenderer)
     json_ld_context = JSON_LD_CONTEXT
+
+    def delete(self, request, **kwargs):
+        id_uriref = URIRef(kwargs.get("annotation"))
+        store = settings.RDFLIB_STORE
+        store.update(delete_annotation_update, initBindings={
+            'annotations': ANNOTATION_GRAPH_IDENTIFIER,
+            'annotation': id_uriref,
+        })
+        store.commit()
+        return Response(Graph())
 
     def put(self, request, **kwargs):
         id_uriref = URIRef(request.data.get("@id"))
@@ -140,7 +137,7 @@ class UpdateAnnotationView(RDFView):
         return Response(graph)
 
 
-class AnnotationsView(RDFView):
+class AnnotationsPerTargetView(RDFView):
     '''
     View the records inside a collection
     '''

--- a/backend/annotations/api.py
+++ b/backend/annotations/api.py
@@ -97,6 +97,7 @@ class AnnotationsView(RDFView):
         'edpoprec': str(EDPOPREC),
         'oa': str(OA),
         'as': str(AS),
+        'dcterms': str(DCTERMS),
     }
 
     def get_graph(self, request: Request, record: str, **kwargs) -> Graph:

--- a/backend/annotations/api.py
+++ b/backend/annotations/api.py
@@ -1,0 +1,86 @@
+import uuid
+from django.conf import settings
+from rest_framework.views import Request
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+from rdflib import URIRef, Graph, Literal, DCTERMS, RDFS
+import datetime
+
+from triplestore.constants import EDPOPREC, AS
+from rdf.views import RDFView
+from rdf.utils import graph_from_triples
+from rdf.renderers import TurtleRenderer, JsonLdRenderer
+from accounts.utils import user_to_uriref
+from triplestore.constants import OA, AS
+from triplestore.utils import triples_to_quads, sparql_multivalues
+
+ANNOTATION_GRAPH_URI = settings.RDF_NAMESPACE_ROOT + "annotations/"
+ANNOTATION_GRAPH_IDENTIFIER = URIRef(ANNOTATION_GRAPH_URI)
+
+RDF_ANNOTATION_ROOT = settings.RDF_NAMESPACE_ROOT + "annotations/"
+
+
+# Argument: target_uris
+collection_records_query = '''
+construct {{
+  ?s ?p ?o .
+}}
+where {{
+  values ?annotation {{ {target_uris} }}
+  graph ?annotations {{
+    ?s ?p ?o.
+    ?s <http://www.w3.org/ns/oa#hasTarget> ?annotation.
+  }}
+}}
+'''.format
+
+
+@api_view(['POST'])
+def add_annotation(request: Request) -> Response:
+    subject_node = URIRef(RDF_ANNOTATION_ROOT + uuid.uuid4().hex)
+    graph = Graph(identifier=ANNOTATION_GRAPH_IDENTIFIER)
+    if not all(x in request.data.keys() for x in ["oa:hasTarget", "oa:hasBody"]):
+        return Response({"error": "Missing required fields"}, status=400)
+    oa_has_target = URIRef(request.data.get("oa:hasTarget"))
+    oa_motivated_by = OA.commenting
+    oa_has_body = Literal(request.data.get("oa:hasBody"))
+    as_published = Literal(datetime.date.today())
+    dcterms_creator = user_to_uriref(request.user)
+    triples = [
+        (subject_node, OA.hasTarget, oa_has_target),
+        (subject_node, OA.motivatedBy, oa_motivated_by),
+        (subject_node, OA.hasBody, oa_has_body),
+        (subject_node, AS.published, as_published),
+        (subject_node, DCTERMS.creator, dcterms_creator),
+    ]
+    quads = list(triples_to_quads(triples, graph))
+    # Get the existing graph from Blazegraph
+    store = settings.RDFLIB_STORE
+    store.addN(quads)
+    store.commit()
+    return Response({})
+
+
+class AnnotationsView(RDFView):
+    '''
+    View the records inside a collection
+    '''
+
+    renderer_classes = (JsonLdRenderer, TurtleRenderer)
+    json_ld_context = {
+        'rdfs': str(RDFS),
+        'edpoprec': str(EDPOPREC),
+        'oa': str(OA),
+        'as': str(AS),
+    }
+
+    def get_graph(self, request: Request, record: str, **kwargs) -> Graph:
+        record_uri = URIRef(record)
+        store = settings.RDFLIB_STORE
+        target_uris = sparql_multivalues([record_uri])
+        query = collection_records_query(target_uris=target_uris)
+        return graph_from_triples(store.query(query, initNs={
+            'rdfs': RDFS,
+        }, initBindings={
+            'annotations': ANNOTATION_GRAPH_IDENTIFIER,
+        }))

--- a/backend/annotations/api.py
+++ b/backend/annotations/api.py
@@ -83,7 +83,7 @@ class AnnotationView(RDFView):
         oa_has_target = URIRef(request.data.get("oa:hasTarget"))
         oa_motivated_by = OA.commenting
         oa_has_body = Literal(request.data.get("oa:hasBody"))
-        as_published = Literal(datetime.date.today())
+        as_published = Literal(datetime.datetime.now())
         dcterms_creator = user_to_uriref(request.user)
         triples = [
             (subject_node, RDF.type, EDPOPCOL.Annotation),
@@ -120,7 +120,7 @@ class AnnotationEditView(RDFView):
     def put(self, request, **kwargs):
         id_uriref = URIRef(kwargs.get("annotation"))
         oa_has_body = Literal(request.data.get("oa:hasBody"))
-        as_updated = Literal(datetime.date.today())
+        as_updated = Literal(datetime.datetime.now())
         store = settings.RDFLIB_STORE
         # Delete the current body
         store.update(delete_annotation_body_update, initBindings={

--- a/backend/annotations/api_test.py
+++ b/backend/annotations/api_test.py
@@ -1,0 +1,54 @@
+import pytest
+from urllib.parse import quote_plus
+
+from rdflib import RDF, URIRef, Literal
+from triplestore.constants import EDPOPCOL, OA
+
+
+@pytest.fixture
+def django_test_user(django_user_model):
+    return django_user_model.objects.create_user(username='tester', password='secret')
+
+
+def annotation_exists_for_target(triplestore, target):
+    return len(list(triplestore.triples((None, OA.hasTarget, URIRef(target))))) == 1
+
+
+def create_annotation(client, target, body, django_test_user) -> str:
+    """Create an annotation through the API and return the URI."""
+    data = {
+        "oa:hasTarget": target,
+        "oa:hasBody": body
+    }
+    client.force_login(django_test_user)
+    response = client.post('/api/annotation/', data, content_type='application/json')
+    assert response.status_code == 200
+    uri = str(list(response.data.subjects(RDF.type, EDPOPCOL.Annotation))[0])
+    return uri
+
+
+def test_create_delete_annotation(client, triplestore, django_test_user):
+    target = 'http://example.com/target'
+    uri = create_annotation(client, target, 'This is an annotation', django_test_user)
+    assert annotation_exists_for_target(triplestore, target)
+    client.delete(f'/api/annotation/{quote_plus(uri)}/', content_type='application/json')
+    assert not annotation_exists_for_target(triplestore, target)
+
+
+def test_edit_annotation(client, triplestore, django_test_user):
+    target = 'http://example.com/target'
+    uri = create_annotation(client, target, 'This is an annotation', django_test_user)
+    client.put(f'/api/annotation/{quote_plus(uri)}/', {'oa:hasBody': 'This is an edited annotation'}, content_type='application/json')
+    body_triple = list(triplestore.triples((URIRef(uri), OA.hasBody, None)))[0][0]
+    assert body_triple[2] == Literal('This is an edited annotation')
+
+
+def test_list_annotations(client, triplestore, django_test_user):
+    target = 'http://example.com/target'
+    uri = create_annotation(client, target, 'This is an annotation', django_test_user)
+    uri2 = create_annotation(client, target, 'This is another annotation', django_test_user)
+    response = client.get(f'/api/annotations-per-target/{quote_plus(target)}/', content_type='application/json')
+    assert response.status_code == 200
+    graph = response.data
+    assert len(list(graph.triples((None, OA.hasTarget, URIRef(target))))) == 2
+

--- a/backend/annotations/apps.py
+++ b/backend/annotations/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class AnnotationsConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'annotations'

--- a/backend/annotations/models.py
+++ b/backend/annotations/models.py
@@ -1,0 +1,3 @@
+from django.db import models
+
+# Create your models here.

--- a/backend/annotations/tests.py
+++ b/backend/annotations/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/backend/annotations/urls.py
+++ b/backend/annotations/urls.py
@@ -3,7 +3,7 @@ from django.urls import path, re_path
 from . import api
 
 urlpatterns = [
-    path('api/annotations/add/', api.add_annotation, name='add_annotation'),
+    path('api/annotations/add/', api.AddAnnotationView.as_view(), name='add_annotation'),
     path('api/annotations/delete/', api.delete_annotation, name='delete_annotation'),
     re_path(r'api/annotations/get/(?P<record>.+)/', api.AnnotationsView.as_view(), name='annotations')
 ]

--- a/backend/annotations/urls.py
+++ b/backend/annotations/urls.py
@@ -3,8 +3,7 @@ from django.urls import path, re_path
 from . import api
 
 urlpatterns = [
-    path('api/annotations/add/', api.AddAnnotationView.as_view(), name='add_annotation'),
-    path('api/annotations/delete/', api.delete_annotation, name='delete_annotation'),
-    path('api/annotations/update/', api.UpdateAnnotationView.as_view(), name='update_annotation'),
-    re_path(r'api/annotations/get/(?P<record>.+)/', api.AnnotationsView.as_view(), name='annotations')
+    re_path(r'api/annotation/(?P<annotation>.+)/', api.AnnotationEditView.as_view(), name='annotation_edit'),
+    path('api/annotation/', api.AnnotationView.as_view(), name='annotation'),
+    re_path(r'api/annotations-per-target/(?P<record>.+)/', api.AnnotationsPerTargetView.as_view(), name='annotations_per_target')
 ]

--- a/backend/annotations/urls.py
+++ b/backend/annotations/urls.py
@@ -5,5 +5,6 @@ from . import api
 urlpatterns = [
     path('api/annotations/add/', api.AddAnnotationView.as_view(), name='add_annotation'),
     path('api/annotations/delete/', api.delete_annotation, name='delete_annotation'),
+    path('api/annotations/update/', api.update_annotation, name='update_annotation'),
     re_path(r'api/annotations/get/(?P<record>.+)/', api.AnnotationsView.as_view(), name='annotations')
 ]

--- a/backend/annotations/urls.py
+++ b/backend/annotations/urls.py
@@ -4,5 +4,6 @@ from . import api
 
 urlpatterns = [
     path('api/annotations/add/', api.add_annotation, name='add_annotation'),
+    path('api/annotations/delete/', api.delete_annotation, name='delete_annotation'),
     re_path(r'api/annotations/get/(?P<record>.+)/', api.AnnotationsView.as_view(), name='annotations')
 ]

--- a/backend/annotations/urls.py
+++ b/backend/annotations/urls.py
@@ -5,6 +5,6 @@ from . import api
 urlpatterns = [
     path('api/annotations/add/', api.AddAnnotationView.as_view(), name='add_annotation'),
     path('api/annotations/delete/', api.delete_annotation, name='delete_annotation'),
-    path('api/annotations/update/', api.update_annotation, name='update_annotation'),
+    path('api/annotations/update/', api.UpdateAnnotationView.as_view(), name='update_annotation'),
     re_path(r'api/annotations/get/(?P<record>.+)/', api.AnnotationsView.as_view(), name='annotations')
 ]

--- a/backend/annotations/urls.py
+++ b/backend/annotations/urls.py
@@ -1,0 +1,8 @@
+from django.urls import path, re_path
+
+from . import api
+
+urlpatterns = [
+    path('api/annotations/add/', api.add_annotation, name='add_annotation'),
+    re_path(r'api/annotations/get/(?P<record>.+)/', api.AnnotationsView.as_view(), name='annotations')
+]

--- a/backend/annotations/views.py
+++ b/backend/annotations/views.py
@@ -1,0 +1,3 @@
+from django.shortcuts import render
+
+# Create your views here.

--- a/backend/annotations/views.py
+++ b/backend/annotations/views.py
@@ -1,3 +1,0 @@
-from django.shortcuts import render
-
-# Create your views here.

--- a/backend/edpop/settings.py
+++ b/backend/edpop/settings.py
@@ -63,6 +63,7 @@ INSTALLED_APPS = [
     'rdf',
     'projects',
     'collect',
+    'annotations',
 ]
 
 MIDDLEWARE = [

--- a/backend/edpop/settings.py
+++ b/backend/edpop/settings.py
@@ -103,7 +103,7 @@ WSGI_APPLICATION = 'edpop.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': 'edpop_reserve',
+        'NAME': 'edpop',
         'USER': 'edpopuser',
         'PASSWORD': 'edpop',
         'HOST': os.getenv('EDPOP_DATABASE_HOST', 'localhost'),

--- a/backend/edpop/settings.py
+++ b/backend/edpop/settings.py
@@ -103,7 +103,7 @@ WSGI_APPLICATION = 'edpop.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': 'edpop',
+        'NAME': 'edpop_reserve',
         'USER': 'edpopuser',
         'PASSWORD': 'edpop',
         'HOST': os.getenv('EDPOP_DATABASE_HOST', 'localhost'),

--- a/backend/edpop/urls.py
+++ b/backend/edpop/urls.py
@@ -34,6 +34,7 @@ api_router.register(r'remove-selection',
 api_router.register('collections', CollectionViewSet, basename='collections')
 
 urlpatterns = [
+    path('', include('annotations.urls')),
     path('admin/', admin.site.urls),
     path('api-auth/',
          include('rest_framework.urls', namespace='rest_framework')),

--- a/frontend/vre/annotation/annotation.edit.view.js
+++ b/frontend/vre/annotation/annotation.edit.view.js
@@ -47,10 +47,7 @@ export var AnnotationEditView = View.extend({
     },
     submit: function(event) {
         event.preventDefault();
-        var model = this.model;
-        this.$('input').each(function(index, element) {
-            model.set(this.name, $(this).val());
-        });
+        this.model.set("value", this.$('textarea').val());
         this.trigger('save', this);
     },
     reset: function(event) {

--- a/frontend/vre/annotation/annotation.edit.view.js
+++ b/frontend/vre/annotation/annotation.edit.view.js
@@ -34,13 +34,10 @@ export var AnnotationEditView = View.extend({
         );
     },
     render: function() {
-        var templateData = {};
-        Object.assign(templateData, {
+        this.$el.html(this.template({
             currentText: this.model.getBody(),
-        });
-        this.$el.html(this.template(
-            _.extend({cid: this.cid}, templateData)
-        ));
+            cid: this.cid,
+        }));
         return this;
     },
     remove: function() {

--- a/frontend/vre/annotation/annotation.edit.view.js
+++ b/frontend/vre/annotation/annotation.edit.view.js
@@ -34,8 +34,12 @@ export var AnnotationEditView = View.extend({
         );
     },
     render: function() {
+        var templateData = {};
+        Object.assign(templateData, {
+            currentText: this.model.getBody(),
+        });
         this.$el.html(this.template(
-            _.extend({cid: this.cid}, this.model.attributes)
+            _.extend({cid: this.cid}, templateData)
         ));
         return this;
     },
@@ -47,7 +51,7 @@ export var AnnotationEditView = View.extend({
     },
     submit: function(event) {
         event.preventDefault();
-        this.model.set("value", this.$('textarea').val());
+        this.model.set("oa:hasBody", this.$('textarea').val());
         this.trigger('save', this);
     },
     reset: function(event) {

--- a/frontend/vre/annotation/annotation.edit.view.mustache
+++ b/frontend/vre/annotation/annotation.edit.view.mustache
@@ -1,25 +1,11 @@
-<td><input
-    type=text
-    name=key
-    form=form-{{cid}}
-    class=form-control
-    placeholder="Field"
-    title="Field annotation name"
-    value="{{key}}"
-    required
-    {{#key}}disabled{{/key}}
-></td>
-<td><input
+<td><textarea
     type=text
     name=value
     form=form-{{cid}}
     class=form-control
-    placeholder="Value"
-    title="Field annotation value"
-    value="{{value}}"
+    title="Comment"
     required
-></td>
-<td><form id=form-{{cid}}>
+>{{value}}</textarea><form id=form-{{cid}} class="mt-2">
     <button type=submit class="btn btn-primary">Save</button>
     <button type=reset class="btn btn-default">Cancel</button>
     <button type=button class="btn btn-danger" aria-label=Delete>

--- a/frontend/vre/annotation/annotation.edit.view.mustache
+++ b/frontend/vre/annotation/annotation.edit.view.mustache
@@ -5,7 +5,7 @@
     class=form-control
     title="Comment"
     required
->{{value}}</textarea><form id=form-{{cid}} class="mt-2">
+>{{currentText}}</textarea><form id=form-{{cid}} class="mt-2">
     <button type=submit class="btn btn-primary">Save</button>
     <button type=reset class="btn btn-default">Cancel</button>
     <button type=button class="btn btn-danger" aria-label=Delete>

--- a/frontend/vre/annotation/annotation.edit.view.test.js
+++ b/frontend/vre/annotation/annotation.edit.view.test.js
@@ -3,10 +3,11 @@ import sinon from 'sinon';
 import { each, after } from 'lodash';
 import { Model, $ } from 'backbone';
 import { AnnotationEditView } from './annotation.edit.view';
+import {Annotation} from "./annotation.model";
 
 describe('AnnotationEditView', function() {
     beforeEach(function() {
-        this.model = new Model();
+        this.model = new Annotation();
         this.view = new AnnotationEditView({model: this.model});
         this.view.render().$el.appendTo('body');
     });
@@ -15,11 +16,10 @@ describe('AnnotationEditView', function() {
         this.view.remove();
     });
 
-    it('renders with two inputs and some buttons', function() {
-        var inputs = this.view.$('input');
-        assert(inputs.length === 2);
-        assert(inputs[0].name === 'key');
-        assert(inputs[1].name === 'value');
+    it('renders with a textarea and some buttons', function() {
+        var textarea = this.view.$('textarea');
+        assert(textarea.length === 1);
+        assert(textarea[0].name === 'value');
         var buttons = this.view.$('button');
         assert(buttons.length === 3);
         assert(buttons[0].textContent === 'Save');
@@ -44,16 +44,13 @@ describe('AnnotationEditView', function() {
     describe('on submit', function() {
         beforeEach(function() {
             this.detectSave = sinon.fake();
-            var inputs = this.view.$('input');
-            inputs.eq(0).val('Color');
-            inputs.eq(1).val('green');
+            var textarea = this.view.$('textarea');
+            textarea.eq(0).val('green');
             this.view.on('save', this.detectSave).$('button').eq(0).click();
         });
 
         it('saves input data to the model', function() {
-            var data = this.model.toJSON();
-            assert(data.key === 'Color');
-            assert(data.value === 'green');
+            assert(this.model.getBody() === 'green');
         });
 
         it('triggers a "save" event', function() {

--- a/frontend/vre/annotation/annotation.model.js
+++ b/frontend/vre/annotation/annotation.model.js
@@ -18,6 +18,11 @@ export var Annotation = JsonLdModel.extend({
             url: `/api/annotations/add/`,
         });
     },
+    saveExisting: function() {
+        this.save(null, {
+            url: `/api/annotations/update/`,
+        });
+    },
     deleteFromDatabase: function() {
         this.save(null, {
             url: `/api/annotations/delete/`,
@@ -30,13 +35,17 @@ export var Annotations = JsonLdNestedCollection.extend({
     initialize: function(model, options) {
         _.assign(this, _.pick(options, ['target']));
         this.url = `/api/annotations/get/${encodeURIComponent(this.target)}/`;
-        this.on('add change:value', this.updateAnnotation);
+        this.on('add', this.addAnnotation);
+        this.on('change', this.updateAnnotation);
         this.on('remove', this.deleteAnnotation);
     },
-    updateAnnotation: function(annotation) {
+    addAnnotation: function(annotation) {
         if (annotation.isNew()) {
             annotation.saveNew(this.target);
         }
+    },
+    updateAnnotation: function(annotation) {
+        annotation.saveExisting();
     },
     deleteAnnotation: function(annotation) {
         annotation.deleteFromDatabase();

--- a/frontend/vre/annotation/annotation.model.js
+++ b/frontend/vre/annotation/annotation.model.js
@@ -5,8 +5,11 @@ export var Annotation = JsonLdModel.extend({
     getBody: function() {
         return this.get('oa:hasBody');
     },
-    getDate: function() {
+    getPublishedDate: function() {
         return getDateLiteral(this.get('as:published'));
+    },
+    getUpdatedDate: function() {
+        return getDateLiteral(this.get('as:updated'));
     },
     getAuthor: function() {
         return new UserLd(this.get('dcterms:creator'));

--- a/frontend/vre/annotation/annotation.model.js
+++ b/frontend/vre/annotation/annotation.model.js
@@ -22,12 +22,6 @@ export var Annotation = JsonLdModel.extend({
             return '/api/annotation/' + encodeURIComponent(this.id) + '/';
         }
     },
-    destroy: function() {
-        this.save(null, {
-            url: '/api/annotation/' + encodeURIComponent(this.id) + '/',
-            method: 'DELETE',
-        })
-    }
 });
 
 export var Annotations = JsonLdNestedCollection.extend({

--- a/frontend/vre/annotation/annotation.model.js
+++ b/frontend/vre/annotation/annotation.model.js
@@ -18,17 +18,18 @@ export var Annotation = JsonLdModel.extend({
         this.save({
             "oa:hasTarget": target,
         }, {
-            url: `/api/annotations/add/`,
+            url: '/api/annotation/',
         });
     },
     saveExisting: function() {
         this.save(null, {
-            url: `/api/annotations/update/`,
+            url: '/api/annotation/' + encodeURIComponent(this.id) + '/',
         });
     },
-    deleteFromDatabase: function() {
+    destroy: function() {
         this.save(null, {
-            url: `/api/annotations/delete/`,
+            url: '/api/annotation/' + encodeURIComponent(this.id) + '/',
+            method: 'DELETE',
         })
     }
 });
@@ -37,7 +38,7 @@ export var Annotations = JsonLdNestedCollection.extend({
     model: Annotation,
     initialize: function(model, options) {
         _.assign(this, _.pick(options, ['target']));
-        this.url = `/api/annotations/get/${encodeURIComponent(this.target)}/`;
+        this.url = `/api/annotations-per-target/${encodeURIComponent(this.target)}/`;
         this.on('add', this.addAnnotation);
         this.on('change', this.updateAnnotation);
         this.on('remove', this.deleteAnnotation);
@@ -51,6 +52,6 @@ export var Annotations = JsonLdNestedCollection.extend({
         annotation.saveExisting();
     },
     deleteAnnotation: function(annotation) {
-        annotation.deleteFromDatabase();
+        annotation.destroy();
     }
 })

--- a/frontend/vre/annotation/annotation.model.js
+++ b/frontend/vre/annotation/annotation.model.js
@@ -16,7 +16,7 @@ export var Annotation = JsonLdModel.extend({
             "oa:hasTarget": target,
         }, {
             url: `/api/annotations/add/`,
-        })
+        });
     },
     deleteFromDatabase: function() {
         this.save(null, {

--- a/frontend/vre/annotation/annotation.model.js
+++ b/frontend/vre/annotation/annotation.model.js
@@ -2,6 +2,7 @@ import {getDateLiteral, JsonLdModel, JsonLdNestedCollection} from "../utils/json
 import {UserLd} from "../user/user.ld.model";
 
 export var Annotation = JsonLdModel.extend({
+    urlRoot: '/api/annotation/',
     getBody: function() {
         return this.get('oa:hasBody');
     },
@@ -14,17 +15,12 @@ export var Annotation = JsonLdModel.extend({
     getAuthor: function() {
         return new UserLd(this.get('dcterms:creator'));
     },
-    saveNew: function(target) {
-        this.save({
-            "oa:hasTarget": target,
-        }, {
-            url: '/api/annotation/',
-        });
-    },
-    saveExisting: function() {
-        this.save(null, {
-            url: '/api/annotation/' + encodeURIComponent(this.id) + '/',
-        });
+    url: function() {
+        if (this.isNew()) {
+            return '/api/annotation/';
+        } else {
+            return '/api/annotation/' + encodeURIComponent(this.id) + '/';
+        }
     },
     destroy: function() {
         this.save(null, {
@@ -39,17 +35,7 @@ export var Annotations = JsonLdNestedCollection.extend({
     initialize: function(model, options) {
         _.assign(this, _.pick(options, ['target']));
         this.url = `/api/annotations-per-target/${encodeURIComponent(this.target)}/`;
-        this.on('add', this.addAnnotation);
-        this.on('change', this.updateAnnotation);
         this.on('remove', this.deleteAnnotation);
-    },
-    addAnnotation: function(annotation) {
-        if (annotation.isNew()) {
-            annotation.saveNew(this.target);
-        }
-    },
-    updateAnnotation: function(annotation) {
-        annotation.saveExisting();
     },
     deleteAnnotation: function(annotation) {
         annotation.destroy();

--- a/frontend/vre/annotation/annotation.model.js
+++ b/frontend/vre/annotation/annotation.model.js
@@ -1,9 +1,12 @@
-import { JsonLdModel, JsonLdNestedCollection } from "../utils/jsonld.model";
+import {getDateLiteral, JsonLdModel, JsonLdNestedCollection} from "../utils/jsonld.model";
 import {UserLd} from "../user/user.ld.model";
 
 export var Annotation = JsonLdModel.extend({
     getBody: function() {
         return this.get('oa:hasBody');
+    },
+    getDate: function() {
+        return getDateLiteral(this.get('as:published'));
     },
     getAuthor: function() {
         return new UserLd(this.get('dcterms:creator'));

--- a/frontend/vre/annotation/annotation.model.js
+++ b/frontend/vre/annotation/annotation.model.js
@@ -1,84 +1,37 @@
-import  Backbone from 'backbone';
-import { APIModel, APICollection } from '../utils/api.model';
-import { canonicalSort } from '../utils/generic-functions';
-import { vreChannel } from '../radio.js';
+import { JsonLdModel, JsonLdNestedCollection } from "../utils/jsonld.model";
 
-export var Annotations = APICollection.extend({
-    url: '/api/annotations',
+export var Annotation = JsonLdModel.extend({
+    getBody: function() {
+        return this.get('oa:hasBody');
+    },
+    saveNew: function(target) {
+        this.save({
+            "oa:hasTarget": target,
+        }, {
+            url: `/api/annotations/add/`,
+        })
+    },
+    deleteFromDatabase: function() {
+        this.save(null, {
+            url: `/api/annotations/delete/`,
+        })
+    }
 });
 
-export var FlatAnnotations = APICollection.extend({
-    comparator: function(item) {
-        return canonicalSort(item.attributes.key);
+export var Annotations = JsonLdNestedCollection.extend({
+    model: Annotation,
+    initialize: function(model, options) {
+        _.assign(this, _.pick(options, ['target']));
+        this.url = `/api/annotations/get/${encodeURIComponent(this.target)}/`;
+        this.on('add change:value', this.updateAnnotation);
+        this.on('remove', this.deleteAnnotation);
     },
-    // How to uniquely identify a field annotation.
-    modelId: function(attributes) {
-        return attributes.key + ':' + attributes.context;
-    },
-    initialize: function(models, options) {
-        _.assign(this, _.pick(options, ['record']));
-        this.underlying = this.record.getAnnotations();
-        this.underlying.forEach(this.toFlat.bind(this));
-        this.markedProjects = new Backbone.Collection([]);
-        this.listenTo(this.underlying, 'add change:content', this.toFlat);
-        this.on('add change:value remove', this.markProject);
-        this.markedProjects.on('add', _.debounce(this.fromFlat), this);
-        // this.listenTo(this.underlying, 'remove', TODO);
-    },
-    // translate the official representation to the flat one
-    toFlat: function(annotation) {
-        if (annotation.isNew() || annotation.hasChanged()) {
-            // Store the annotation either immediately or on record save.
-            if (this.record.isNew()) {
-                this.listenToOnce(annotation, 'change:record', function() {
-                    annotation.save(null, {silent: true});
-                });
-            } else annotation.save(null, {silent: true});
+    updateAnnotation: function(annotation) {
+        if (annotation.isNew()) {
+            annotation.saveNew(this.target);
         }
-        var id = annotation.id,
-            projectId = annotation.get('context'),
-            projectName = vreChannel.request('projects:get', projectId).get('name'),
-            content = annotation.get('content'),
-            existing = _.map(this.filter({ context: projectName }), 'attributes'),
-            replacements = _.map(content, function(value, key) {
-                return { id: id, key: key, value: value, context: projectName };
-            }),
-            obsolete = _.differenceBy(existing, replacements, this.modelId);
-        // After the next two lines, this.models will be up-to-date and
-        // appropriate events will have been triggered.
-        this.remove(obsolete);
-        this.add(replacements, {merge: true});
     },
-    markProject: function (flatAnnotation) {
-        this.markedProjects.add({ id: flatAnnotation.get('context') });
-    },
-    // translate the flat representation to the official one, save immediately
-    fromFlat: function() {
-        var flat = this,
-            record = flat.record,
-            recordId = record.id,
-            flatPerProject = flat.groupBy('context');
-        var newContent = flat.markedProjects.map('id').map(function (projectName) {
-            var projectId = vreChannel.request('projects:find', { name: projectName }).id,
-                existing = flat.underlying.findWhere({ context: projectId }),
-                id = existing && existing.id,
-                annotations = flatPerProject[projectName],
-                content = annotations && _(annotations).map(function(model) {
-                    return [model.get('key'), model.get('value')];
-                }).fromPairs().value() || {};
-            return {
-                id: id,
-                record: recordId,
-                context: projectId,
-                content: content,
-            };
-        });
-        // At least one annotation exists, so now is the time to ensure
-        // the VRE knows the record.
-        if (record.isNew()) record.save().then(function() {
-            _.invokeMap(flat.underlying.models, 'set', 'record', record.id);
-        });
-        flat.underlying.add(newContent, {merge: true});
-        flat.markedProjects.reset();
-    },
-});
+    deleteAnnotation: function(annotation) {
+        annotation.deleteFromDatabase();
+    }
+})

--- a/frontend/vre/annotation/annotation.model.js
+++ b/frontend/vre/annotation/annotation.model.js
@@ -1,8 +1,12 @@
 import { JsonLdModel, JsonLdNestedCollection } from "../utils/jsonld.model";
+import {UserLd} from "../user/user.ld.model";
 
 export var Annotation = JsonLdModel.extend({
     getBody: function() {
         return this.get('oa:hasBody');
+    },
+    getAuthor: function() {
+        return new UserLd(this.get('dcterms:creator'));
     },
     saveNew: function(target) {
         this.save({

--- a/frontend/vre/annotation/annotation.model.js
+++ b/frontend/vre/annotation/annotation.model.js
@@ -1,4 +1,4 @@
-import {getDateLiteral, JsonLdModel, JsonLdNestedCollection} from "../utils/jsonld.model";
+import {getDateTimeLiteral, JsonLdModel, JsonLdNestedCollection} from "../utils/jsonld.model";
 import {UserLd} from "../user/user.ld.model";
 
 export var Annotation = JsonLdModel.extend({
@@ -7,10 +7,10 @@ export var Annotation = JsonLdModel.extend({
         return this.get('oa:hasBody');
     },
     getPublishedDate: function() {
-        return getDateLiteral(this.get('as:published'));
+        return getDateTimeLiteral(this.get('as:published'));
     },
     getUpdatedDate: function() {
-        return getDateLiteral(this.get('as:updated'));
+        return getDateTimeLiteral(this.get('as:updated'));
     },
     getAuthor: function() {
         return new UserLd(this.get('dcterms:creator'));

--- a/frontend/vre/annotation/comment.view.js
+++ b/frontend/vre/annotation/comment.view.js
@@ -13,7 +13,7 @@ export var CommentView = View.extend({
     },
 
     initialize: function(options) {
-        this.render().listenTo(this.model, 'change:value sync', this.render);
+        this.render().listenTo(this.model, 'change', this.render);
     },
 
     render: function() {

--- a/frontend/vre/annotation/comment.view.js
+++ b/frontend/vre/annotation/comment.view.js
@@ -13,7 +13,7 @@ export var CommentView = View.extend({
     },
 
     initialize: function(options) {
-        this.render().listenTo(this.model, 'change:value', this.render);
+        this.render().listenTo(this.model, 'change:value sync', this.render);
     },
 
     render: function() {

--- a/frontend/vre/annotation/comment.view.js
+++ b/frontend/vre/annotation/comment.view.js
@@ -22,7 +22,7 @@ export var CommentView = View.extend({
         // custom models
         var templateData = {};
         Object.assign(templateData, {
-            displayText: this.model.get('value'),
+            displayText: this.model.getBody(),
         });
         this.$el.html(this.template(templateData));
         return this;

--- a/frontend/vre/annotation/comment.view.js
+++ b/frontend/vre/annotation/comment.view.js
@@ -21,8 +21,11 @@ export var CommentView = View.extend({
         // there are some tests relating to old-style annotations that assign
         // custom models
         var templateData = {};
+        var author = this.model.getAuthor();
         Object.assign(templateData, {
             displayText: this.model.getBody(),
+            author: (author ? author.getUsername() : null),
+            date: (date ? date.toLocaleDateString() : null),
         });
         this.$el.html(this.template(templateData));
         return this;

--- a/frontend/vre/annotation/comment.view.js
+++ b/frontend/vre/annotation/comment.view.js
@@ -35,6 +35,6 @@ export var CommentView = View.extend({
     },
 
     edit: function(event) {
-        this.trigger('edit', this.model);
+        this.model.trigger('edit', this.model);
     },
 });

--- a/frontend/vre/annotation/comment.view.js
+++ b/frontend/vre/annotation/comment.view.js
@@ -27,8 +27,8 @@ export var CommentView = View.extend({
         Object.assign(templateData, {
             displayText: this.model.getBody(),
             author: (author ? author.getUsername() : null),
-            publishedDate: (publishedDate ? publishedDate.toLocaleDateString() : null),
-            updatedDate: (updatedDate ? updatedDate.toLocaleDateString() : null),
+            publishedDate: (publishedDate ? publishedDate.toLocaleString() : null),
+            updatedDate: (updatedDate ? updatedDate.toLocaleString() : null),
         });
         this.$el.html(this.template(templateData));
         return this;

--- a/frontend/vre/annotation/comment.view.js
+++ b/frontend/vre/annotation/comment.view.js
@@ -21,6 +21,7 @@ export var CommentView = View.extend({
         // there are some tests relating to old-style annotations that assign
         // custom models
         var templateData = {};
+        var date = this.model.getDate();
         var author = this.model.getAuthor();
         Object.assign(templateData, {
             displayText: this.model.getBody(),

--- a/frontend/vre/annotation/comment.view.js
+++ b/frontend/vre/annotation/comment.view.js
@@ -1,0 +1,34 @@
+import { View } from '../core/view.js';
+import commentTemplate from './comment.view.mustache';
+
+/**
+ * Displays a single model from a FlatFields or FlatAnnotations collection.
+ */
+export var CommentView = View.extend({
+    tagName: 'tr',
+    template: commentTemplate,
+
+    events: {
+        'click': 'edit',
+    },
+
+    initialize: function(options) {
+        this.render().listenTo(this.model, 'change:value', this.render);
+    },
+
+    render: function() {
+        // Check if model is of Field model before using these methods, because
+        // there are some tests relating to old-style annotations that assign
+        // custom models
+        var templateData = {};
+        Object.assign(templateData, {
+            displayText: this.model.get('value'),
+        });
+        this.$el.html(this.template(templateData));
+        return this;
+    },
+
+    edit: function(event) {
+        this.trigger('edit', this.model);
+    },
+});

--- a/frontend/vre/annotation/comment.view.js
+++ b/frontend/vre/annotation/comment.view.js
@@ -21,12 +21,14 @@ export var CommentView = View.extend({
         // there are some tests relating to old-style annotations that assign
         // custom models
         var templateData = {};
-        var date = this.model.getDate();
+        var publishedDate = this.model.getPublishedDate();
+        var updatedDate = this.model.getUpdatedDate();
         var author = this.model.getAuthor();
         Object.assign(templateData, {
             displayText: this.model.getBody(),
             author: (author ? author.getUsername() : null),
-            date: (date ? date.toLocaleDateString() : null),
+            publishedDate: (publishedDate ? publishedDate.toLocaleDateString() : null),
+            updatedDate: (updatedDate ? updatedDate.toLocaleDateString() : null),
         });
         this.$el.html(this.template(templateData));
         return this;

--- a/frontend/vre/annotation/comment.view.mustache
+++ b/frontend/vre/annotation/comment.view.mustache
@@ -1,1 +1,1 @@
-<td>{{displayText}} <span class="authored-by">@{{author}}</span></td>
+<td title="{{date}}">{{displayText}} <span class="authored-by">@{{author}}</span></td>

--- a/frontend/vre/annotation/comment.view.mustache
+++ b/frontend/vre/annotation/comment.view.mustache
@@ -1,1 +1,1 @@
-<td>{{displayText}}</td>
+<td>{{displayText}} <span class="authored-by">@{{author}}</span></td>

--- a/frontend/vre/annotation/comment.view.mustache
+++ b/frontend/vre/annotation/comment.view.mustache
@@ -1,0 +1,1 @@
+<td>{{displayText}}</td>

--- a/frontend/vre/annotation/comment.view.mustache
+++ b/frontend/vre/annotation/comment.view.mustache
@@ -1,1 +1,1 @@
-<td title="{{date}}">{{displayText}} <span class="authored-by">@{{author}}</span></td>
+<td title="{{date}}">{{displayText}} {{#author}}<span class="authored-by">@{{author}}</span>{{/author}} </td>

--- a/frontend/vre/annotation/comment.view.mustache
+++ b/frontend/vre/annotation/comment.view.mustache
@@ -1,1 +1,1 @@
-<td title="{{date}}">{{displayText}} {{#author}}<span class="authored-by">@{{author}}</span>{{/author}} </td>
+<td title="{{publishedDate}}{{#updatedDate}} (updated: {{updatedDate}}){{/updatedDate}}">{{displayText}} {{#author}}<span class="authored-by">@{{author}}</span>{{/author}} </td>

--- a/frontend/vre/css/style.css
+++ b/frontend/vre/css/style.css
@@ -6,6 +6,11 @@ h2 {
     color: cornflowerblue;
 }
 
+.authored-by {
+    font-size: 0.8em;
+    color: #888;
+}
+
 #result_detail td {
     cursor: pointer;
 }

--- a/frontend/vre/digitization/digitization.view.mustache
+++ b/frontend/vre/digitization/digitization.view.mustache
@@ -1,4 +1,4 @@
-<div class="card">
+<div class="card mb-2">
     {{#previewUrl}}
         <img src="{{previewUrl}}" alt="Digitization preview" class="card-img-top">
     {{/previewUrl}}

--- a/frontend/vre/field/field.view.js
+++ b/frontend/vre/field/field.view.js
@@ -8,10 +8,6 @@ export var FieldView = View.extend({
     tagName: 'tr',
     template: fieldTemplate,
 
-    events: {
-        'click': 'edit',
-    },
-
     initialize: function(options) {
         this.render().listenTo(this.model, 'change:value', this.render);
     },
@@ -31,9 +27,5 @@ export var FieldView = View.extend({
         }
         this.$el.html(this.template(templateData));
         return this;
-    },
-
-    edit: function(event) {
-        this.trigger('edit', this.model);
     },
 });

--- a/frontend/vre/field/field.view.test.js
+++ b/frontend/vre/field/field.view.test.js
@@ -48,10 +48,4 @@ describe('FieldView', function() {
         assert(newText.includes(newExpectedText));
         assert(!newText.includes(oldExpectedTest));
     });
-
-    it('triggers an edit event when clicked', function() {
-        var detectEdit = sinon.fake();
-        this.view.on('edit', detectEdit).$el.click();
-        assert(detectEdit.called);
-    });
 });

--- a/frontend/vre/field/record.annotations.view.js
+++ b/frontend/vre/field/record.annotations.view.js
@@ -5,6 +5,7 @@ import { vreChannel } from '../radio.js';
 import {AggregateView} from "../core/view";
 import recordAnnotationsTemplate from "./record.annotations.view.mustache";
 import {CommentView} from "../annotation/comment.view";
+import {Annotation} from "../annotation/annotation.model";
 
 export var RecordAnnotationsView = AggregateView.extend({
     template: recordAnnotationsTemplate,
@@ -53,7 +54,7 @@ export var RecordAnnotationsView = AggregateView.extend({
     },
 
     editEmpty: function() {
-        this.edit(new Backbone.Model());
+        this.edit(new Annotation());
     },
 
     cancel: function(editRow) {

--- a/frontend/vre/field/record.annotations.view.js
+++ b/frontend/vre/field/record.annotations.view.js
@@ -10,12 +10,7 @@ import {Annotation} from "../annotation/annotation.model";
 export var RecordAnnotationsView = AggregateView.extend({
     template: recordAnnotationsTemplate,
     container: 'tbody',
-
-    makeItem: function(model) {
-        var row = new CommentView({model: model});
-        row.on('edit', this.edit, this);
-        return row;
-    },
+    subview: CommentView,
 
     renderContainer: function() {
         this.$el.html(this.template(this));
@@ -24,6 +19,7 @@ export var RecordAnnotationsView = AggregateView.extend({
 
     initialize: function(options) {
         this.initItems().render().initCollectionEvents();
+        this.listenTo(this.collection, 'edit', this.edit);
         this.editable = true;  // enables "New field" button
     },
 

--- a/frontend/vre/field/record.annotations.view.js
+++ b/frontend/vre/field/record.annotations.view.js
@@ -2,13 +2,27 @@ import _ from 'lodash';
 import Backbone from 'backbone';
 import { AnnotationEditView } from '../annotation/annotation.edit.view';
 import { vreChannel } from '../radio.js';
-import { RecordFieldsBaseView } from './record.base.view';
+import {AggregateView} from "../core/view";
+import recordAnnotationsTemplate from "./record.annotations.view.mustache";
+import {CommentView} from "../annotation/comment.view";
 
-export var RecordAnnotationsView = RecordFieldsBaseView.extend({
-    title: 'Annotations',
+export var RecordAnnotationsView = AggregateView.extend({
+    template: recordAnnotationsTemplate,
+    container: 'tbody',
+
+    makeItem: function(model) {
+        var row = new CommentView({model: model});
+        row.on('edit', this.edit, this);
+        return row;
+    },
+
+    renderContainer: function() {
+        this.$el.html(this.template(this));
+        return this;
+    },
 
     initialize: function(options) {
-        RecordFieldsBaseView.prototype.initialize.call(this, options);
+        this.initItems().render().initCollectionEvents();
         this.editable = true;  // enables "New field" button
     },
 

--- a/frontend/vre/field/record.annotations.view.js
+++ b/frontend/vre/field/record.annotations.view.js
@@ -54,7 +54,9 @@ export var RecordAnnotationsView = AggregateView.extend({
     },
 
     editEmpty: function() {
-        this.edit(new Annotation());
+        this.edit(new Annotation({
+            "oa:hasTarget": this.collection.target,
+        }));
     },
 
     cancel: function(editRow) {
@@ -71,6 +73,7 @@ export var RecordAnnotationsView = AggregateView.extend({
         var model = editRow.model;
         this.cancel(editRow);
         this.collection.add(model, {merge: true});
+        model.save();
     },
 
     trash: function(editRow) {

--- a/frontend/vre/field/record.annotations.view.mustache
+++ b/frontend/vre/field/record.annotations.view.mustache
@@ -1,0 +1,7 @@
+<h5 class="mb-2">Comments</h5>
+<div>
+    <table class="table table-light table-hover"><tbody></tbody></table>
+    {{#editable}}
+    <button type=button class="btn btn-primary">New comment</button>
+    {{/editable}}
+</div>

--- a/frontend/vre/field/record.annotations.view.test.js
+++ b/frontend/vre/field/record.annotations.view.test.js
@@ -162,40 +162,6 @@ describe('RecordAnnotationsView', function() {
         describe('on trash', newAnnotationTrashed);
     });
 
-    describe('when editing a previously unedited field', function() {
-        beforeEach(function() {
-            this.fieldView = this.view.items[0];
-            this.affectedModel = this.fieldView.model;
-            assert(this.affectedModel === this.collection.at(0));
-            assert(this.affectedModel.get('context') !== currentContext);
-            this.affectedElement = this.fieldView.$el;
-            assert(this.affectedElement.get(0) === this.view.$('tr').get(0));
-            this.affectedElement.click();
-            this.editor = last(this.view.items);
-        });
-
-        it('leaves the original row in place', function() {
-            assert(this.detectChange.notCalled);
-            assert(this.detectRemove.notCalled);
-            assert(this.fieldView === this.view.items[0]);
-            assert(this.affectedModel === this.collection.at(0));
-            assert(this.affectedElement.get(0) === this.view.$('tr').get(0));
-        });
-
-        it('appends a new AnnotationEditView', assertEditorAppended);
-
-        it('copies key and value but overrides the context', function () {
-            var newModel = this.editor.model;
-            assert(newModel.get('key') === this.affectedModel.get('key'));
-            assert(newModel.get('value') === this.affectedModel.get('value'));
-            assert(newModel.get('context') === currentContext);
-        });
-
-        describe('on cancel', newAnnotationCanceled);
-        describe('on save', newAnnotationSaved);
-        describe('on trash', newAnnotationTrashed);
-    });
-
     describe('when editing a previously edited field', function() {
         beforeEach(function() {
             this.position = 1;

--- a/frontend/vre/field/record.annotations.view.test.js
+++ b/frontend/vre/field/record.annotations.view.test.js
@@ -4,7 +4,7 @@ import { isEmpty, last, indexOf, find, compact } from 'lodash';
 import { Collection }  from 'backbone';
 
 import { vreChannel } from '../radio.js';
-import { FlatAnnotations } from '../annotation/annotation.model.js';
+import {Annotation, Annotations} from '../annotation/annotation.model.js';
 import { AnnotationEditView } from '../annotation/annotation.edit.view.js';
 import { RecordFieldsBaseView } from './record.base.view.js';
 import { RecordAnnotationsView } from './record.annotations.view.js';
@@ -22,18 +22,20 @@ var fakeProjectMenu = {
 };
 
 var TestCollection = Collection.extend({
-    modelId: FlatAnnotations.prototype.modelId,
+    modelId: Annotations.prototype.modelId,
 });
 
-var testAnnotations = [{
-    key: 'Color',
-    value: 'moss',
-    context: 'me, myself and I',
-}, {
-    key: 'Pet',
-    value: 'Slimey',
-    context: currentContext,
-}];
+var annotation = new Annotation({
+    "@id": "http://example.org/annotations/1",
+    "oa:hasBody": "moss",
+    context: "me, myself and I",
+});
+var annotation2 = new Annotation({
+    "@id": "http://example.org/annotations/2",
+    "oa:hasBody": "bright",
+    context: "monsters",
+});
+var testAnnotations = [annotation, annotation2];
 
 var numAnnotations = testAnnotations.length;
 var oneUp = numAnnotations + 1;
@@ -140,15 +142,11 @@ describe('RecordAnnotationsView', function() {
         vreChannel.stopReplying('projects:current');
     });
 
-    it('inherits from RecordFieldsBaseView', function() {
-        assert(this.view instanceof RecordFieldsBaseView);
-    });
-
     it('has a button for adding new fields', function() {
         var button = this.view.$('table + button');
         assert(button.length === 1);
         var text = button.text();
-        assert(/new.+field/i.test(text));
+        assert(/new.+comment/i.test(text));
     });
 
     describe('when adding a new field', function() {

--- a/frontend/vre/field/record.fields.view.js
+++ b/frontend/vre/field/record.fields.view.js
@@ -1,7 +1,27 @@
-import { RecordFieldsBaseView } from './record.base.view';
+import {AggregateView} from "../core/view";
+import fieldListTemplate from "./record.fields.view.mustache";
+import {FieldView} from "./field.view";
 
-export var RecordFieldsView = RecordFieldsBaseView.extend({
-    title: 'Normalized content',
+
+export var RecordFieldsView = AggregateView.extend({
+    template: fieldListTemplate,
+    container: 'tbody',
+
+    initialize: function(options) {
+        this.initItems().render().initCollectionEvents();
+    },
+
+    makeItem: function(model) {
+        var row = new FieldView({model: model});
+        row.on('edit', this.edit, this);
+        return row;
+    },
+
+    renderContainer: function() {
+        this.$el.html(this.template(this));
+        return this;
+    },
+
     edit: function(model) {
         this.trigger('edit', model);
     },

--- a/frontend/vre/field/record.fields.view.mustache
+++ b/frontend/vre/field/record.fields.view.mustache
@@ -1,0 +1,4 @@
+<h5 class="mb-2">Fields</h5>
+<div>
+    <table class="table table-light table-hover"><tbody></tbody></table>
+</div>

--- a/frontend/vre/record/record.detail.view.js
+++ b/frontend/vre/record/record.detail.view.js
@@ -2,7 +2,6 @@ import _ from 'lodash';
 import { FilteredCollection } from "../utils/filtered.collection";
 import { CompositeView } from '../core/view.js';
 import { vreChannel } from '../radio';
-import { FlatAnnotations } from '../annotation/annotation.model';
 import { RecordFieldsView } from '../field/record.fields.view';
 import { RecordAnnotationsView } from '../field/record.annotations.view';
 import { Field, FlatterFields } from '../field/field.model';
@@ -56,6 +55,7 @@ export var RecordDetailView = CompositeView.extend({
 
     initialize: function(options) {
         var model = this.model;
+        model.getAnnotations();
         var index = model.collection.indexOf(model);
         this.isFirst = (index === 0);
         this.isLast = (index === model.collection.length - 1);
@@ -73,7 +73,7 @@ export var RecordDetailView = CompositeView.extend({
             model: model,
         });
         this.annotationsView = new RecordAnnotationsView({
-            collection: new FlatAnnotations(null, {record: model}),
+            collection: model.annotations,
         }).render();
         this.annotationsView.listenTo(this.fieldsView, 'edit', this.annotationsView.edit);
         this.addSelect = new AddToCollectionView({

--- a/frontend/vre/record/record.detail.view.js
+++ b/frontend/vre/record/record.detail.view.js
@@ -31,9 +31,6 @@ export var RecordDetailView = CompositeView.extend({
     subviews: [{
         view: 'fieldsView',
         selector: '#main-content'
-    },{
-        view: 'annotationsView',
-        selector: '#main-content'
     }, {
         view: 'removeButton',
         selector: '.modal-footer',
@@ -41,12 +38,15 @@ export var RecordDetailView = CompositeView.extend({
     }, {
         view: 'addSelect',
         selector: '.modal-footer'
-    },{
+    }, {
         view: 'aboutView',
         selector: '#side-content',
-    },{
+    }, {
         view: 'digitizationsView',
         selector: '#side-content',
+    }, {
+        view: 'annotationsView',
+        selector: '#side-content'
     }],
 
     events: {

--- a/frontend/vre/record/record.model.js
+++ b/frontend/vre/record/record.model.js
@@ -39,10 +39,10 @@ export var Record = JsonLdModel.extend({
     },
     getAnnotations: function() {
         if (!this.annotations) {
-            this.annotations = new Annotations();
-            if (!this.isNew()) this.annotations.query({
-                params: {record__id: this.id}
-            });
+            this.annotations = new Annotations(null, {target: this.id});
+            if (!this.isNew()) {
+                this.annotations.fetch();
+            }
         }
         return this.annotations;
     },

--- a/frontend/vre/user/user.ld.model.js
+++ b/frontend/vre/user/user.ld.model.js
@@ -1,0 +1,15 @@
+import {JsonLdModel} from "../utils/jsonld.model";
+
+/**
+ * Model to represent the LD version of a user. This model stands next to
+ * User, which works with a REST API and which is used to get the
+ * information about the currently logged-in user, but they may be
+ * merged in the future.
+ */
+export var UserLd = JsonLdModel.extend({
+    getUsername: function() {
+        // Extract username from URI
+        if (!this.id) return null;
+        return this.id.split('/').pop();
+    }
+});

--- a/frontend/vre/utils/jsonld.model.js
+++ b/frontend/vre/utils/jsonld.model.js
@@ -55,7 +55,8 @@ export var JsonLdCollection = APICollection.extend({
     model: JsonLdModel,
     parse: function(response) {
         if (!response.hasOwnProperty("@graph")) {
-            throw "Response has no @graph key, is this JSON-LD in compacted form?";
+            console.warn("Response has no @graph key; assuming that it is in compacted form.");
+            return [response];
         }
         return response["@graph"];
     }
@@ -119,10 +120,11 @@ export var JsonLdNestedCollection = APICollection.extend({
      */
     targetClass: undefined,
     parse: function(response) {
+        let allSubjects = response["@graph"];
         if (!response.hasOwnProperty("@graph")) {
-            throw "Response has no @graph key, is this JSON-LD in compacted form?";
+            console.warn("Response has no @graph key; assuming that it is in compacted form.");
+            allSubjects = [response];
         }
-        const allSubjects = response["@graph"];
         const completeSubjects = enforest(allSubjects, !this.targetClass);
         if (!this.targetClass) return completeSubjects;
         return _.filter(completeSubjects, {'@type': this.targetClass});

--- a/frontend/vre/utils/jsonld.model.js
+++ b/frontend/vre/utils/jsonld.model.js
@@ -44,6 +44,18 @@ export function getStringLiteral(literalObject) {
 }
 
 /**
+ * Check whether the given literal is of the given data type.
+ * @param literalObject - the object to be checked
+ * @param expectedType - the expected XSD type (part after xsd:)
+ * @returns {boolean}
+ */
+function checkDataType(literalObject, expectedType) {
+    if (expectedType === "string")
+        return typeof literalObject === "string";
+    return typeof literalObject === "object" && Object.hasOwn(literalObject, "@type") && literalObject["@type"] === "http://www.w3.org/2001/XMLSchema#" + expectedType;
+}
+
+/**
  * Get a date literal from JSON-LD. This function probes whether the literal
  * is of xsd:string or xsd:date format and tries to return a Date object.
  * If the date cannot be reliably parsed, return null.
@@ -51,15 +63,19 @@ export function getStringLiteral(literalObject) {
  * @return {?Date}
  */
 export function getDateLiteral(literalObject) {
-    if (typeof literalObject === "string") {
-        // Only accept dates in the format YYYY-MM-DD
-        if (literalObject.match(/^\d{4}-\d{2}-\d{2}-(?:Z|[+-]\d{2}:\d{2})?$/)) {
-            return new Date(literalObject);
-        }
-    } else if (typeof literalObject === "object" && Object.hasOwn(literalObject, "@value") && Object.hasOwn(literalObject, "@type") && literalObject["@type"] === "http://www.w3.org/2001/XMLSchema#date") {
+    if (checkDataType(literalObject, "date")) {
         return new Date(literalObject["@value"]);
+    } else {
+        return null;
     }
-    return null;
+}
+
+export function getDateTimeLiteral(literalObject) {
+    if (checkDataType(literalObject, "dateTime")) {
+        return new Date(literalObject["@value"]);
+    } else {
+        return null;
+    }
 }
 
 export var JsonLdModel = Backbone.Model.extend({

--- a/frontend/vre/utils/jsonld.model.js
+++ b/frontend/vre/utils/jsonld.model.js
@@ -49,7 +49,7 @@ export function getStringLiteral(literalObject) {
  * @param expectedType - the expected XSD type (part after xsd:)
  * @returns {boolean}
  */
-function checkDataType(literalObject, expectedType) {
+function hasDataType(literalObject, expectedType) {
     if (expectedType === "string")
         return typeof literalObject === "string";
     return typeof literalObject === "object" && Object.hasOwn(literalObject, "@type") && literalObject["@type"] === "http://www.w3.org/2001/XMLSchema#" + expectedType;
@@ -63,7 +63,7 @@ function checkDataType(literalObject, expectedType) {
  * @return {?Date}
  */
 export function getDateLiteral(literalObject) {
-    if (checkDataType(literalObject, "date")) {
+    if (hasDataType(literalObject, "date")) {
         return new Date(literalObject["@value"]);
     } else {
         return null;
@@ -71,7 +71,7 @@ export function getDateLiteral(literalObject) {
 }
 
 export function getDateTimeLiteral(literalObject) {
-    if (checkDataType(literalObject, "dateTime")) {
+    if (hasDataType(literalObject, "dateTime")) {
         return new Date(literalObject["@value"]);
     } else {
         return null;

--- a/frontend/vre/utils/jsonld.model.js
+++ b/frontend/vre/utils/jsonld.model.js
@@ -43,6 +43,25 @@ export function getStringLiteral(literalObject) {
     }, null);
 }
 
+/**
+ * Get a date literal from JSON-LD. This function probes whether the literal
+ * is of xsd:string or xsd:date format and tries to return a Date object.
+ * If the date cannot be reliably parsed, return null.
+ * @param literalObject
+ * @return {?Date}
+ */
+export function getDateLiteral(literalObject) {
+    if (typeof literalObject === "string") {
+        // Only accept dates in the format YYYY-MM-DD
+        if (literalObject.match(/^\d{4}-\d{2}-\d{2}-(?:Z|[+-]\d{2}:\d{2})?$/)) {
+            return new Date(literalObject);
+        }
+    } else if (typeof literalObject === "object" && Object.hasOwn(literalObject, "@value") && Object.hasOwn(literalObject, "@type") && literalObject["@type"] === "http://www.w3.org/2001/XMLSchema#date") {
+        return new Date(literalObject["@value"]);
+    }
+    return null;
+}
+
 export var JsonLdModel = Backbone.Model.extend({
     idAttribute: '@id',
 });


### PR DESCRIPTION
Add functionality to create, edit and remove annotations to records as a whole (record comments), which closes #19.

Until now, the views for fields and annotations were combined, but this PR separates them, as we discussed before. Fields and annotations are now completely different things. This separation takes place in [c09b766](https://github.com/CentreForDigitalHumanities/EDPOP/pull/286/commits/c09b7664469105c64879a9a2e3a47190f86e0f2f), where some files are splitted and renamed.

Functionality to annotate specific fields (besides commenting also suggesting addition, removal and alteration) will be added later. I expect that large parts of both the API and the web-ui can be reused here.

For now, the API only supports fetching annotations that belong to one single record. In the future, we will need to show the annotations in the table as well (#273), but fetching annotations for single records will remain necessary if we implement #277.