### PR TITLE
Add taxonomy functionality

### DIFF
--- a/backend/annotations/api.py
+++ b/backend/annotations/api.py
@@ -83,7 +83,7 @@ class AnnotationView(RDFView):
         oa_has_target = URIRef(request.data.get("oa:hasTarget"))
         oa_motivated_by_value = request.data.get("oa:motivatedBy")
         oa_motivated_by_id = oa_motivated_by_value and oa_motivated_by_value.get("@id")
-        oa_has_body_value = request.data.get("oa:hasBody)
+        oa_has_body_value = request.data.get("oa:hasBody")
         if oa_motivated_by_id in ("oa:commenting", None):
             oa_has_body = Literal(oa_has_body_value)
             oa_motivated_by = OA.commenting

--- a/backend/annotations/api.py
+++ b/backend/annotations/api.py
@@ -81,8 +81,15 @@ class AnnotationView(RDFView):
         if not all(x in request.data.keys() for x in ["oa:hasTarget", "oa:hasBody"]):
             return Response({"error": "Missing required fields"}, status=400)
         oa_has_target = URIRef(request.data.get("oa:hasTarget"))
-        oa_motivated_by = OA.commenting
-        oa_has_body = Literal(request.data.get("oa:hasBody"))
+        oa_motivated_by_value = request.data.get("oa:motivatedBy")
+        if oa_motivated_by_value and oa_motivated_by_value.get("@id") == "oa:commenting" or not oa_motivated_by_value:
+            oa_has_body = Literal(request.data.get("oa:hasBody"))
+            oa_motivated_by = OA.commenting
+        elif oa_motivated_by_value and oa_motivated_by_value.get("@id") == "oa:tagging":
+            oa_has_body = URIRef(request.data.get("oa:hasBody"))
+            oa_motivated_by = OA.tagging
+        else:
+            return Response({"error": "Invalid oa:motivatedBy value"}, status=400)
         as_published = Literal(datetime.datetime.now())
         dcterms_creator = user_to_uriref(request.user)
         triples = [

--- a/backend/annotations/api.py
+++ b/backend/annotations/api.py
@@ -82,11 +82,13 @@ class AnnotationView(RDFView):
             return Response({"error": "Missing required fields"}, status=400)
         oa_has_target = URIRef(request.data.get("oa:hasTarget"))
         oa_motivated_by_value = request.data.get("oa:motivatedBy")
-        if oa_motivated_by_value and oa_motivated_by_value.get("@id") == "oa:commenting" or not oa_motivated_by_value:
-            oa_has_body = Literal(request.data.get("oa:hasBody"))
+        oa_motivated_by_id = oa_motivated_by_value and oa_motivated_by_value.get("@id")
+        oa_has_body_value = request.data.get("oa:hasBody)
+        if oa_motivated_by_id in ("oa:commenting", None):
+            oa_has_body = Literal(oa_has_body_value)
             oa_motivated_by = OA.commenting
-        elif oa_motivated_by_value and oa_motivated_by_value.get("@id") == "oa:tagging":
-            oa_has_body = URIRef(request.data.get("oa:hasBody"))
+        elif oa_motivated_by_id == "oa:tagging":
+            oa_has_body = URIRef(oa_has_body_value)
             oa_motivated_by = OA.tagging
         else:
             return Response({"error": "Invalid oa:motivatedBy value"}, status=400)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,7 +28,7 @@
         "@rollup/plugin-babel": "^6.0.3",
         "@rollup/plugin-commonjs": "^24.0.1",
         "@rollup/plugin-inject": "^5.0.3",
-        "@rollup/plugin-json": "^6.0.0",
+        "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^15.0.1",
         "@rollup/plugin-terser": "^0.4.0",
         "babel-preset-power-assert": "^3.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,7 @@
     "@rollup/plugin-babel": "^6.0.3",
     "@rollup/plugin-commonjs": "^24.0.1",
     "@rollup/plugin-inject": "^5.0.3",
-    "@rollup/plugin-json": "^6.0.0",
+    "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@rollup/plugin-terser": "^0.4.0",
     "babel-preset-power-assert": "^3.0.0",
@@ -40,6 +40,7 @@
     "sinon": "^14.0.1"
   },
   "dependencies": {
+    "@popperjs/core": "^2.11.8",
     "@uu-cdh/backbone-collection-transformers": "^0.1.0",
     "@uu-cdh/backbone-util": "^0.1.1",
     "backbone": "^1.3.3",
@@ -50,7 +51,6 @@
     "jscookie": "^1.1.0",
     "karma-chrome-launcher": "^3.2.0",
     "lodash": "^4.17.21",
-    "@popperjs/core": "^2.11.8",
     "select2": "^4.0.13",
     "wontache": "^0.2.0"
   }

--- a/frontend/rollup.config.js
+++ b/frontend/rollup.config.js
@@ -3,6 +3,7 @@ import wontache from 'rollup-plugin-wontache';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import terser from '@rollup/plugin-terser';
+import json from "@rollup/plugin-json";
 
 var underscorePattern = /node_modules\/underscore($|\/)/;
 var extension = /.js$/;
@@ -14,6 +15,7 @@ export default {
         wontache(),
         nodeResolve(),
         commonjs(),
+        json(),
     ],
     output: {
         file: 'vre/bundle.js',

--- a/frontend/vre/annotation/annotation.model.js
+++ b/frontend/vre/annotation/annotation.model.js
@@ -32,6 +32,9 @@ export var Annotation = JsonLdModel.extend({
             return 'comment';
         } else if (motivationId === 'oa:tagging') {
             return 'tag';
+        } else {
+            console.warn('Unsupported annotation type: ' + motivationId);
+            return null;
         }
     },
     url: function() {

--- a/frontend/vre/annotation/annotation.model.js
+++ b/frontend/vre/annotation/annotation.model.js
@@ -25,11 +25,16 @@ export var Annotation = JsonLdModel.extend({
         return new UserLd(this.get('dcterms:creator'));
     },
     getAnnotationType: function() {
-        var motivation = this.get('oa:motivatedBy')["@id"];
-        if (motivation === 'oa:commenting') {
-            return 'comment';
-        } else if (motivation === 'oa:tagging') {
-            return 'tag';
+        var motivation = this.get('oa:motivatedBy');
+        if (motivation) {
+            var motivationId = motivation["@id"];
+            if (motivationId === 'oa:commenting') {
+                return 'comment';
+            } else if (motivationId === 'oa:tagging') {
+                return 'tag';
+            }
+        } else {
+            return null;
         }
     },
     url: function() {

--- a/frontend/vre/annotation/annotation.model.js
+++ b/frontend/vre/annotation/annotation.model.js
@@ -26,15 +26,12 @@ export var Annotation = JsonLdModel.extend({
     },
     getAnnotationType: function() {
         var motivation = this.get('oa:motivatedBy');
-        if (motivation) {
-            var motivationId = motivation["@id"];
-            if (motivationId === 'oa:commenting') {
-                return 'comment';
-            } else if (motivationId === 'oa:tagging') {
-                return 'tag';
-            }
-        } else {
-            return null;
+        if (!motivation) return null;
+        var motivationId = motivation["@id"];
+        if (motivationId === 'oa:commenting') {
+            return 'comment';
+        } else if (motivationId === 'oa:tagging') {
+            return 'tag';
         }
     },
     url: function() {

--- a/frontend/vre/annotation/annotation.model.js
+++ b/frontend/vre/annotation/annotation.model.js
@@ -1,10 +1,19 @@
 import {getDateTimeLiteral, JsonLdModel, JsonLdNestedCollection} from "../utils/jsonld.model";
 import {UserLd} from "../user/user.ld.model";
+import {glossary} from "../utils/glossary";
 
 export var Annotation = JsonLdModel.extend({
     urlRoot: '/api/annotation/',
     getBody: function() {
         return this.get('oa:hasBody');
+    },
+    getDisplayText: function() {
+        if (this.getAnnotationType() === 'comment') {
+            return this.getBody();
+        } else if (this.getAnnotationType() === 'tag') {
+            var id = this.getBody();
+            return glossary.get(id).get('skos:prefLabel');
+        }
     },
     getPublishedDate: function() {
         return getDateTimeLiteral(this.get('as:published'));
@@ -14,6 +23,14 @@ export var Annotation = JsonLdModel.extend({
     },
     getAuthor: function() {
         return new UserLd(this.get('dcterms:creator'));
+    },
+    getAnnotationType: function() {
+        var motivation = this.get('oa:motivatedBy')["@id"];
+        if (motivation === 'oa:commenting') {
+            return 'comment';
+        } else if (motivation === 'oa:tagging') {
+            return 'tag';
+        }
     },
     url: function() {
         if (this.isNew()) {

--- a/frontend/vre/annotation/annotation.tag.edit.view.mustache
+++ b/frontend/vre/annotation/annotation.tag.edit.view.mustache
@@ -1,0 +1,15 @@
+<td>
+    <form id=form-{{cid}}>
+        <div class="mb-2">
+            <select name="glossaryitem" style="width: 100%;" id="glossary-select-{{cid}}" required class="mb-2">
+                <option value="">Select a glossary item</option>
+                {{#choices}}<option value={{@id}}>{{skos:prefLabel}}</option>{{/choices}}
+            </select>
+        </div>
+        <button type=submit class="btn btn-primary">Save</button>
+        <button type=reset class="btn btn-default">Cancel</button>
+        <button type=button class="btn btn-danger" aria-label=Delete>
+            <span class="fa fa-trash" aria-hidden=true></span>
+        </button>
+    </form>
+</td>

--- a/frontend/vre/annotation/comment.view.js
+++ b/frontend/vre/annotation/comment.view.js
@@ -25,7 +25,8 @@ export var CommentView = View.extend({
         var updatedDate = this.model.getUpdatedDate();
         var author = this.model.getAuthor();
         Object.assign(templateData, {
-            displayText: this.model.getBody(),
+            isTag: this.model.getAnnotationType() === 'tag',
+            displayText: this.model.getDisplayText(),
             author: (author ? author.getUsername() : null),
             publishedDate: (publishedDate ? publishedDate.toLocaleString() : null),
             updatedDate: (updatedDate ? updatedDate.toLocaleString() : null),

--- a/frontend/vre/annotation/comment.view.mustache
+++ b/frontend/vre/annotation/comment.view.mustache
@@ -1,1 +1,1 @@
-<td title="{{publishedDate}}{{#updatedDate}} (updated: {{updatedDate}}){{/updatedDate}}">{{displayText}} {{#author}}<span class="authored-by">@{{author}}</span>{{/author}} </td>
+<td title="{{publishedDate}}{{#updatedDate}} (updated: {{updatedDate}}){{/updatedDate}}">{{#isTag}}<b>Tag: </b>{{/isTag}}{{displayText}} {{#author}}<span class="authored-by">@{{author}}</span>{{/author}} </td>

--- a/frontend/vre/field/record.annotations.view.js
+++ b/frontend/vre/field/record.annotations.view.js
@@ -24,7 +24,8 @@ export var RecordAnnotationsView = AggregateView.extend({
     },
 
     events: {
-        'click table + button': 'editEmpty',
+        'click button.new-comment': 'editEmpty',
+        'click button.new-tag': 'editEmptyTag',
     },
 
     edit: function(model) {
@@ -52,7 +53,15 @@ export var RecordAnnotationsView = AggregateView.extend({
     editEmpty: function() {
         this.edit(new Annotation({
             "oa:hasTarget": this.collection.target,
+            "oa:motivatedBy": {"@id": "oa:commenting"},
         }));
+    },
+
+    editEmptyTag: function() {
+        this.edit(new Annotation({
+            "oa:hasTarget": this.collection.target,
+            "oa:motivatedBy": {"@id": "oa:tagging"},
+        }))
     },
 
     cancel: function(editRow) {

--- a/frontend/vre/field/record.annotations.view.mustache
+++ b/frontend/vre/field/record.annotations.view.mustache
@@ -1,7 +1,8 @@
-<h5 class="mb-2">Comments</h5>
+<h5 class="mb-2">Comments and tags</h5>
 <div>
     <table class="table table-light table-hover"><tbody></tbody></table>
     {{#editable}}
-    <button type=button class="btn btn-primary">New comment</button>
+    <button type=button class="btn btn-primary new-comment">New comment</button>
+    <button type=button class="btn btn-primary new-tag">New tag</button>
     {{/editable}}
 </div>

--- a/frontend/vre/gemppg.json
+++ b/frontend/vre/gemppg.json
@@ -1,0 +1,394 @@
+{
+  "@context": {
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "skos": "http://www.w3.org/2004/02/skos/core#"
+  },
+  "@graph": [
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/plague-sheet-book/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:prefLabel": "Plague sheet/book"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/game-printed-on-paper/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:prefLabel": "Game (printed on paper)"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/playbill/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:prefLabel": "Playbill/Playbook"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/topical-poetry/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:altLabel": "News poem",
+      "skos:prefLabel": "Topical poetry"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/broadsheet-broadside/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:prefLabel": "Broadsheet (broadside)"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/ballad/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:altLabel": [
+        "Song/Song book",
+        "Cantari"
+      ],
+      "skos:prefLabel": "Ballad"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/relation/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:prefLabel": "Relation"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/journal/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:prefLabel": "Journal"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/criminal-narrative/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:prefLabel": "Criminal narrative"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/prayer-book/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:prefLabel": "Prayer book"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/new-year-prints/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:prefLabel": "New Year prints"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/form/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:altLabel": "Indulgence",
+      "skos:prefLabel": "Form"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/pamphlet/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:prefLabel": "Pamphlet"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/devotional-literature/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:prefLabel": "Devotional literature"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/medical-literature/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:prefLabel": "Medical literature"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/gazette/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:prefLabel": "Gazette"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/herbal/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:prefLabel": "Herbal"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/catechism-primer/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:altLabel": "Rooster primer",
+      "skos:prefLabel": "Catechism primer"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/chapbook/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:prefLabel": "Chapbook"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/prognostication/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:prefLabel": "Prognostication"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/lottery-ticket/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:prefLabel": "Lottery ticket"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/tidings/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:prefLabel": "Tidings"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/nouvelle/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:prefLabel": "Nouvelle"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/mercury/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:prefLabel": "Mercury"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/sermon/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:prefLabel": "Sermon"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/travel-accounts-and-guides/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:prefLabel": "Travel accounts and guides"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/household-manual/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:prefLabel": "Household manual"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/cookbook/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:prefLabel": "Cookbook"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/news-pamphlet/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:altLabel": [
+        "History print",
+        "Canard"
+      ],
+      "skos:prefLabel": "News pamphlet"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/history/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:altLabel": "Narrative",
+      "skos:prefLabel": "History"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/saints-life/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:altLabel": "Lives of saints",
+      "skos:prefLabel": "Saint's life"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/catechism/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:prefLabel": "Catechism"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/report/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:prefLabel": "Report"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/coranto/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:prefLabel": "Coranto"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/how-to-book/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:prefLabel": "How-to book"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/book-of-secrets/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:altLabel": "Recipe book",
+      "skos:prefLabel": "Book of secrets"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/romance/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:altLabel": [
+        "Prose romance",
+        "Novel"
+      ],
+      "skos:prefLabel": "Romance"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/jestbook/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:prefLabel": "Jestbook"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/aviso/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:prefLabel": "Aviso"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/libel-pasquil/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:altLabel": "Pasquil",
+      "skos:prefLabel": "Libel/pasquil"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/abecedarium/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:prefLabel": "Abecedarium"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/martyr-story/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:prefLabel": "Martyr story"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/childrens-book-and-schoolbook/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:altLabel": "Schoolbook",
+      "skos:prefLabel": "Children's book and schoolbook"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/penny-print/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:prefLabel": "Penny print"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/newspaper/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:prefLabel": "Newspaper"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/regimen-book/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:prefLabel": "Regimen book"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/proclamation/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:altLabel": "Ordinance",
+      "skos:prefLabel": "Proclamation"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/chronicle-chronology/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:prefLabel": "Chronicle/Chronology"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/almanac/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:prefLabel": "Almanac"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/hornbook/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:altLabel": "Battledore",
+      "skos:prefLabel": "Hornbook"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/newsbook/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:prefLabel": "Newsbook"
+    },
+    {
+      "@id": "https://popular-print-glossary.sites.uu.nl/glossary/rooster-primer-2/",
+      "rdfs:member": {
+        "@id": "https://popular-print-glossary.sites.uu.nl/glossary/"
+      },
+      "skos:prefLabel": "Rooster primer"
+    }
+  ]
+}

--- a/frontend/vre/utils/glossary.js
+++ b/frontend/vre/utils/glossary.js
@@ -1,0 +1,9 @@
+import {JsonLdCollection} from "./jsonld.model";
+
+export var Glossary = JsonLdCollection.extend({
+    url: "/static/gemppg.json",
+    comparator: 'skos:prefLabel',
+});
+
+export var glossary = new Glossary();
+glossary.fetch();

--- a/frontend/vre/utils/glossary.js
+++ b/frontend/vre/utils/glossary.js
@@ -1,9 +1,10 @@
 import {JsonLdCollection} from "./jsonld.model";
+import gemppg from "../gemppg.json";
 
 export var Glossary = JsonLdCollection.extend({
-    url: "/static/gemppg.json",
     comparator: 'skos:prefLabel',
 });
 
-export var glossary = new Glossary();
-glossary.fetch();
+export var glossary = new Glossary(gemppg, {
+    parse: true,
+});


### PR DESCRIPTION
This PR adds the taxonomy functionality to the VRE, closing #237. The approach I took is very simple: adding a taxonomy classification is like adding an annotation, but instead of a comment it is a tag (with `oa:tagging` instead of `oa:commenting` as motivation). In the frontend, the user chooses whether they want to add a comment or a tag and the widget is rendered accordingly. The options are taken from the RDF version of the Glossary (https://github.com/CentreForDigitalHumanities/edpop-glossary).