### PR TITLE
Create content graph in a more efficient way

### DIFF
--- a/backend/catalogs/graphs.py
+++ b/backend/catalogs/graphs.py
@@ -162,7 +162,9 @@ class SearchGraphBuilder:
         results = self.records
         record_nodes = map(attrgetter('subject_node'), results)
         graphs = [x.to_graph() for x in results if isinstance(x, Record)]
-        content_graph = sum(graphs, Graph())
+        content_graph = Graph()
+        quads = [(s, p, o, content_graph) for g in graphs for (s, p, o) in g.triples((None, None, None))]
+        content_graph.addN(quads)
         remove_from_triplestore(results)
         save_to_triplestore(content_graph, record_nodes)
         return content_graph


### PR DESCRIPTION
This PR aims to close #217 

@jgonggrijp : I copied the solution you proposed in your comment in #217 and it seems to solve the problem completely. Retrieval is still slow in some cases, but that is caused by the external APIs. The speed is especially visible when querying USTC, since this is a local database and it is now very fast, even when fetching 500 new records at once.