### PR TITLE
Record reloading and links to other records

### DIFF
--- a/backend/catalogs/api.py
+++ b/backend/catalogs/api.py
@@ -1,4 +1,6 @@
+from django.conf import settings
 from edpop_explorer import ReaderError
+from edpop_explorer.readers.utils import get_record_by_uri
 from typing import Optional
 
 from rdf.renderers import TurtleRenderer, JsonLdRenderer
@@ -10,15 +12,54 @@ from rest_framework.renderers import JSONRenderer
 
 from triplestore.constants import EDPOPREC, AS
 from .graphs import SearchGraphBuilder, get_catalogs_graph, get_reader_by_uriref
+from .triplestore import get_single_record, save_to_triplestore, remove_from_triplestore
+
+JSON_LD_CONTEXT = {
+    "edpoprec": str(EDPOPREC),
+    "as": str(AS),
+}
+
+
+class RecordView(RDFView):
+    """Get a single record."""
+    renderer_classes = (JsonLdRenderer,)
+    json_ld_context = JSON_LD_CONTEXT
+
+    def get_graph(self, request: views.Request, **kwargs) -> Graph:
+        force_reload = False
+        if request.headers.get("Force-Reload") == "true":
+            force_reload = True
+        reader = kwargs.get("reader")
+        record_id = kwargs.get("record")
+        record_uri = "https://edpop.hum.uu.nl/readers/" + reader + "/" + record_id
+        record_uriref = URIRef(record_uri)
+
+        if not force_reload:
+            # First check if it is already in the triplestore
+            graph = get_single_record(record_uriref)
+            if (record_uriref, None, None) in graph:
+                # Record exists in triplestore; return it
+                return graph
+
+        try:
+            record = get_record_by_uri(record_uri, settings.CATALOG_READERS)
+        except ReaderError as e:
+            raise ParseError("Could not fetch record: " + str(e))
+        if record is not None:
+            graph = record.to_graph()
+            if force_reload:
+                # In case of force reload, the record might already be in the
+                # triplestore. Remove it to avoid duplications.
+                remove_from_triplestore([record])
+            save_to_triplestore(graph, [record_uriref])
+            return graph
+        raise ParseError(f"Could not fetch record")
 
 
 class SearchView(RDFView):
     """Search in a given external catalog according to a query."""
     renderer_classes = (JsonLdRenderer,)
-    json_ld_context = {
-        "edpoprec": str(EDPOPREC),
-        "as": str(AS),
-    }
+    json_ld_context = JSON_LD_CONTEXT
 
     def get_graph(self, request: views.Request, **kwargs) -> Graph:
         try:

--- a/backend/catalogs/urls.py
+++ b/backend/catalogs/urls.py
@@ -5,4 +5,5 @@ from . import api
 urlpatterns = [
     path('api/catalogs/search/', api.SearchView.as_view()),
     path('api/catalogs/catalogs/', api.CatalogsView.as_view()),
+    path('readers/<slug:reader>/<slug:record>', api.RecordView.as_view(), name='record'),
 ]

--- a/frontend/vre/field/field.model.js
+++ b/frontend/vre/field/field.model.js
@@ -5,7 +5,6 @@ import {
     typeTranslation,
 } from '../utils/generic-functions';
 import {
-    fieldList,
     properties,
     biblioProperties,
     bioProperties,
@@ -51,6 +50,10 @@ export var Field = Backbone.Model.extend({
             return {name: this.id};
         }
     },
+    getLinkedUri() {
+        var value = this.get('value');
+        return value && value['edpoprec:authorityRecord'] && value['edpoprec:authorityRecord']['@id'];
+    }
 });
 
 /**

--- a/frontend/vre/field/field.view.js
+++ b/frontend/vre/field/field.view.js
@@ -37,6 +37,10 @@ export var FieldView = AnnotatableView.extend({
                 displayText: this.model.getMainDisplay(),
                 fieldInfo: this.model.getFieldInfo(),
             });
+            var linkedUri = this.model.getLinkedUri();
+            if (linkedUri) {
+                templateData.linkedRecordUri = encodeURIComponent(linkedUri);
+            }
         }
         this.$el.html(this.template(templateData));
         return this;

--- a/frontend/vre/field/field.view.mustache
+++ b/frontend/vre/field/field.view.mustache
@@ -1,3 +1,6 @@
 <td><u title="{{fieldInfo.description}}">{{fieldInfo.name}}</u></td>
-<td><div>{{displayText}}</div><div class="annotations"></div></td>
+<td><div>
+    {{#linkedRecordUri}}<a href="/record/{{linkedRecordUri}}" target="_blank" title="Go to linked record">{{displayText}}</a>{{/linkedRecordUri}}
+    {{^linkedRecordUri}}{{displayText}}{{/linkedRecordUri}}
+</div><div class="annotations"></div></td>
 <td><a class="fa-regular fa-message comment" role="button"></a></td>

--- a/frontend/vre/main.js
+++ b/frontend/vre/main.js
@@ -23,6 +23,7 @@ import {Catalogs} from "./catalog/catalog.model";
 import {SelectCatalogView} from "./catalog/select-catalog.view";
 import { StateModel } from './utils/state.model.js';
 import { WelcomeView } from './utils/welcome.view.js';
+import {Record} from "./record/record.model";
 
 // Dangerously global variable (accessible from dependency modules).
 GlobalVariables.myCollections = new VRECollections();
@@ -51,6 +52,7 @@ var VRERouter = Backbone.Router.extend({
     routes: {
         'collection/:id/': 'showCollection',
         'catalog/:id/': 'showCatalog',
+        'record/:id': 'showRecord',
     },
 });
 
@@ -68,6 +70,9 @@ router.on({
         browsingType: 'catalog',
         browsingContext: catalogs.findWhere({identifier: id})
     }),
+    'route:showRecord': id => {
+        showRecord(id);
+    },
 });
 
 // Focus/blur semantics for the catalog or collection currently being viewed.
@@ -97,6 +102,17 @@ function showCollection(vreCollection) {
 
 function hideCollection(vreCollection) {
     unsalientCollections.add(vreCollection);
+}
+
+function showRecord(id) {
+    var model = new Record({
+        "@id": id
+    });
+    model.fetch({
+        success: function(model) {
+            vreChannel.trigger('displayRecord', model);
+        }
+    });
 }
 
 GlobalVariables.myCollections.on({

--- a/frontend/vre/record/record.detail.view.js
+++ b/frontend/vre/record/record.detail.view.js
@@ -51,6 +51,7 @@ export var RecordDetailView = CompositeView.extend({
     events: {
         'click #load_next': 'next',
         'click #load_previous': 'previous',
+        'click #reload': 'reload',
     },
 
     initialize: function(options) {
@@ -137,4 +138,9 @@ export var RecordDetailView = CompositeView.extend({
         event.preventDefault();
         vreChannel.trigger('displayPreviousRecord');
     },
+
+    reload: function(event) {
+        event.preventDefault();
+        this.model.reload();
+    }
 });

--- a/frontend/vre/record/record.detail.view.js
+++ b/frontend/vre/record/record.detail.view.js
@@ -56,9 +56,11 @@ export var RecordDetailView = CompositeView.extend({
     initialize: function(options) {
         var model = this.model;
         model.getAnnotations();
-        var index = model.collection.indexOf(model);
-        this.isFirst = (index === 0);
-        this.isLast = (index === model.collection.length - 1);
+        if (model.collection) {
+            var index = model.collection.indexOf(model);
+            this.isFirst = (index === 0);
+            this.isLast = (index === model.collection.length - 1);
+        }
         var fields = new FlatterFields(null, {record: model});
         var digitizations = new FilteredCollection(fields, {
             key: 'edpoprec:digitization'
@@ -94,6 +96,7 @@ export var RecordDetailView = CompositeView.extend({
             last: this.isLast,
             title: this.model.getMainDisplay(),
             uri: this.model.id,
+            inContext: this.model.collection ? true : false,
         }, typeTranslation(this.model)), renderOptions));
         return this;
     },

--- a/frontend/vre/record/record.detail.view.mustache
+++ b/frontend/vre/record/record.detail.view.mustache
@@ -11,6 +11,10 @@
                 </button>{{/inContext}}
                 <button
                     class="btn btn-outline-primary"
+                    id="reload"
+                >
+                    <span class="fa fa-rotate-right" aria-hidden="true"></span>
+                </button>
                 {{#inContext}}<button
                     class="btn btn-outline-primary"
                     id="load_next"

--- a/frontend/vre/record/record.detail.view.mustache
+++ b/frontend/vre/record/record.detail.view.mustache
@@ -2,20 +2,22 @@
     <div class="modal-content">
         <div class="modal-header">
             <div class="btn-group me-2">
-                <button
+                {{#inContext}}<button
                     class="btn btn-outline-primary"
                     id="load_previous"
                     {{#first}}disabled{{/first}}
                 >
                     <span class="fa fa-arrow-left" aria-hidden="true"></span>
-                </button>
+                </button>{{/inContext}}
                 <button
+                    class="btn btn-outline-primary"
+                {{#inContext}}<button
                     class="btn btn-outline-primary"
                     id="load_next"
                     {{#last}}disabled{{/last}}
                 >
                     <span class="fa fa-arrow-right" aria-hidden="true"></span>
-                </button>
+                </button>{{/inContext}}
             </div>
             <h4 class="modal-title text-truncate">
                 {{>typeIcon}}

--- a/frontend/vre/record/record.model.js
+++ b/frontend/vre/record/record.model.js
@@ -1,8 +1,16 @@
-import { APIModel } from '../utils/api.model';
 import { Annotations } from '../annotation/annotation.model';
-import { JsonLdModel, JsonLdNestedCollection } from "../utils/jsonld.model";
+import { JsonLdModel, JsonLdNestedCollection} from "../utils/jsonld.model";
 import { FlatFields } from "../field/field.model";
 import {vreChannel} from "../radio";
+
+/**
+ * Get the URL to fetch the record on its own from the backend.
+ * @param {string} record_uri
+ * @returns {string}
+ */
+function get_fetch_url(record_uri) {
+    return record_uri.replace('https://edpop.hum.uu.nl/', '/');
+}
 
 export var Record = JsonLdModel.extend({
     urlRoot: '/api/records',
@@ -50,6 +58,22 @@ export var Record = JsonLdModel.extend({
         const catalog = this.get('edpoprec:fromCatalog');
         const catalogUri = catalog && catalog['@id'];
         return vreChannel.request('getCatalog', catalogUri).getName();
+    },
+    url: function() {
+        if (this.id)
+            return get_fetch_url(this.id);
+        else
+            return this.urlRoot;
+    },
+    reload: function() {
+        /* Fetch the record with 'Force-Reload' to make sure that the
+           backend reloads the record from the original catalogue.
+         */
+        this.fetch({
+            headers: {
+                'Force-Reload': 'true'
+            }
+        });
     },
 });
 

--- a/frontend/vre/record/record.type.icon.mustache
+++ b/frontend/vre/record/record.type.icon.mustache
@@ -1,8 +1,8 @@
 {{#isBibliographical}}
 <span class="fa fa-book" aria-hidden=true></span>
-<span class="sr-only">Bibliographical</span>
+<span class="visually-hidden">Bibliographical</span>
 {{/isBibliographical}}
 {{#isBiographical}}
 <span class="fa fa-user" aria-hidden=true></span>
-<span class="sr-only">Biographical</span>
+<span class="visually-hidden">Biographical</span>
 {{/isBiographical}}

--- a/frontend/vre/utils/jsonld.model.js
+++ b/frontend/vre/utils/jsonld.model.js
@@ -80,6 +80,22 @@ export function getDateTimeLiteral(literalObject) {
 
 export var JsonLdModel = Backbone.Model.extend({
     idAttribute: '@id',
+    parse: function(response) {
+        if (!response['@context']) {
+            // Response is a partial parse by JsonLdNestedCollection; ignore
+            return response;
+        } else {
+            var allSubjects;
+            if (!response.hasOwnProperty("@graph")) {
+                console.warn("Response has no @graph key; assuming that it is in compacted form.");
+                allSubjects = [response];
+            } else {
+                allSubjects = response["@graph"];
+            }
+            var completeSubjects = enforest(allSubjects, true);
+            return completeSubjects[0];
+        }
+    }
 });
 
 /**


### PR DESCRIPTION
This PR implements the following related things:

- Add an API view to load single records from the backend (from the triplestore if available, and otherwise through the Explorer)
- Add a `parse` method to `JsonLdModel` so that it can parse incoming data for single subjects
- Allow reloading of records through the detail view
- Add simple routing for showing individual records (close #277)
- Show links to related records from the detail view (now made available through the Explorer - after https://github.com/CentreForDigitalHumanities/edpop-explorer/pull/83 - only for STCN) (close #278)

Feedback I would be particularly interested in:
- I chose to make the RDF of records available through the URIs that the Explorer generates, such as https://edpop.hum.uu.nl/readers/stcn/822911183. That will only match after deployment to the production server, of course, so they are rewritten to `<domain>/readers/stcn/822911183` to make it work wherever. This approach may fail though if readers with other URI roots are added in the future, although that is very hypothetical for now. What do you think?
- I extended the routing in a very basic way: it allows opening of single records in a new window/tab, but it does not add routing to records that are opened in the normal way. It seems to work reliably, but perhaps there are things I did not think about.