### PR TITLE
Restructure annotations

### DIFF
--- a/backend/annotations/api.py
+++ b/backend/annotations/api.py
@@ -1,138 +1,171 @@
+import datetime
 import uuid
 from django.conf import settings
-from django.http.response import HttpResponse
 from rest_framework.views import Request
-from rest_framework.parsers import JSONParser
-from rest_framework.decorators import api_view, renderer_classes
 from rest_framework.response import Response
+from rest_framework.exceptions import ValidationError
 from rdflib import URIRef, Graph, Literal, DCTERMS, RDFS, RDF
-import datetime
-
-from triplestore.constants import EDPOPREC, AS, EDPOPCOL
-from rdf.views import RDFView
+from rdf.views import RDFView, graph_from_request
 from rdf.utils import graph_from_triples
 from rdf.renderers import TurtleRenderer, JsonLdRenderer
+
 from accounts.utils import user_to_uriref
-from triplestore.constants import OA, AS
-from triplestore.utils import triples_to_quads, sparql_multivalues
+from triplestore.constants import EDPOPREC, OA, AS, EDPOPCOL
+from triplestore.utils import (
+    replace_blank_nodes_in_triples,
+    replace_node,
+    sparql_multivalues,
+    triples_to_quads,
+)
 
 ANNOTATION_GRAPH_URI = settings.RDF_NAMESPACE_ROOT + "annotations/"
 ANNOTATION_GRAPH_IDENTIFIER = URIRef(ANNOTATION_GRAPH_URI)
 
 RDF_ANNOTATION_ROOT = settings.RDF_NAMESPACE_ROOT + "annotations/"
 
+NS = {
+    'rdfs': RDFS,
+    'edpoprec': EDPOPREC,
+    'edpopcol': EDPOPCOL,
+    'oa': OA,
+    'as': AS,
+    'dcterms': DCTERMS,
+}
+
 JSON_LD_CONTEXT = {
-    'rdfs': str(RDFS),
-    'edpoprec': str(EDPOPREC),
-    'edpopcol': str(EDPOPCOL),
-    'oa': str(OA),
-    'as': str(AS),
-    'dcterms': str(DCTERMS),
+    prefix: str(namespace)
+    for prefix, namespace in NS.items()
 }
 
 
-# Argument: target_uris
-collection_records_query = '''
-construct {{
-  ?s ?p ?o .
-}}
-where {{
-  values ?annotation {{ {target_uris} }}
-  graph ?annotations {{
-    ?s ?p ?o.
-    ?s <http://www.w3.org/ns/oa#hasTarget> ?annotation.
-  }}
-}}
-'''.format
+record_annotations_query = '''
+construct {
+  ?a ?pa ?oa .
+  ?t ?pt ?ot .
+  ?s ?ps ?os .
+}
+where {
+  graph ?annotations {
+    ?a ?pa ?oa ;
+       oa:hasTarget ?t .
+    ?t ?pt ?ot ;
+       oa:hasSource ?record .
+    optional {
+      ?t oa:hasSelector ?s .
+      ?s ?ps ?os .
+    }
+  }
+}
+'''
 
 delete_annotation_update = '''
 delete {
   graph ?annotations {
-    ?annotation ?p ?o.
+    ?annotation ?pa ?oa .
+    ?target ?pt ?ot .
+    ?selector ?ps ?os .
   }
 }
 where {
   graph ?annotations {
-    ?annotation ?p ?o.
+    ?annotation ?pa ?oa .
+    optional {
+      ?annotation oa:hasTarget ?target .
+      ?target ?pt ?ot .
+      optional {
+        ?target oa:hasSelector ?selector .
+        ?selector ?ps ?os .
+      }
+    }
   }
 }
 '''
 
-delete_annotation_body_update = '''
+update_annotation_body = '''
 delete {
   graph ?annotations {
-    ?annotation <http://www.w3.org/ns/oa#hasBody> ?o.
+    ?annotation oa:hasBody ?o .
+  }
+}
+insert {
+  graph ?annotations {
+    ?annotation oa:hasBody ?body ;
+                as:updated ?updated .
   }
 }
 where {
   graph ?annotations {
-    ?annotation <http://www.w3.org/ns/oa#hasBody> ?o.
+    ?annotation oa:hasBody ?o .
   }
 }
 '''
-
-
-def get_edpoprec_uriref(string: str) -> URIRef:
-    partial = string.removeprefix("edpoprec:")
-    return EDPOPREC[partial]
-
-
-def create_field_selectors_triples(data: dict, subject_node: URIRef) -> list:
-    triples = []
-    select_field = data.get("edpopcol:selectField")
-    select_original_text = data.get("edpopcol:selectOriginalText")
-    if select_field:
-        select_field_uriref = get_edpoprec_uriref(select_field)
-        triples.append((subject_node, EDPOPCOL.selectField, select_field_uriref))
-    if select_original_text:
-        triples.append((subject_node, EDPOPCOL.selectOriginalText, Literal(select_original_text)))
-    return triples
 
 
 class AnnotationView(RDFView):
-    parser_classes = (JSONParser,)
     renderer_classes = (JsonLdRenderer, TurtleRenderer)
     json_ld_context = JSON_LD_CONTEXT
 
     def post(self, request, **kwargs):
-        subject_node = URIRef(RDF_ANNOTATION_ROOT + uuid.uuid4().hex)
-        graph = Graph(identifier=ANNOTATION_GRAPH_IDENTIFIER)
-        if not all(x in request.data.keys() for x in ["oa:hasTarget", "oa:hasBody"]):
-            return Response({"error": "Missing required fields"}, status=400)
-        oa_has_target = URIRef(request.data.get("oa:hasTarget"))
-        oa_motivated_by_value = request.data.get("oa:motivatedBy")
-        oa_motivated_by_id = oa_motivated_by_value and oa_motivated_by_value.get("@id")
-        oa_has_body_value = request.data.get("oa:hasBody")
-        if oa_motivated_by_id in ("oa:commenting", None):
-            oa_has_body = Literal(oa_has_body_value)
-            oa_motivated_by = OA.commenting
-        elif oa_motivated_by_id == "oa:tagging":
-            oa_has_body = URIRef(oa_has_body_value)
-            oa_motivated_by = OA.tagging
+        request_graph = graph_from_request(request)
+
+        # Step 1: validate the incoming data.
+        bodies = list(request_graph.subject_objects(OA.hasBody))
+        targets = list(request_graph.subject_objects(OA.hasTarget))
+        sources = list(request_graph.subject_objects(OA.hasSource))
+        if len(bodies) == 1:
+            s1, body = bodies[0]
         else:
-            return Response({"error": "Invalid oa:motivatedBy value"}, status=400)
-        as_published = Literal(datetime.datetime.now())
-        dcterms_creator = user_to_uriref(request.user)
-        triples = [
-            (subject_node, RDF.type, EDPOPCOL.Annotation),
-            (subject_node, OA.hasTarget, oa_has_target),
-            (subject_node, OA.motivatedBy, oa_motivated_by),
-            (subject_node, OA.hasBody, oa_has_body),
-            (subject_node, AS.published, as_published),
-            (subject_node, DCTERMS.creator, dcterms_creator),
-        ]
-        triples.extend(create_field_selectors_triples(request.data, subject_node))
-        quads = list(triples_to_quads(triples, graph))
+            raise ValidationError('Needs exactly one body')
+        if len(targets) == 1:
+            s2, target = targets[0]
+        else:
+            raise ValidationError('Needs exactly one target')
+        if len(sources) == 1:
+            s3, source = sources[0]
+        else:
+            raise ValidationError('Needs exactly one source')
+        if s1 != s2:
+            raise ValidationError('Body and target must be annotation properties')
+        if s3 != target:
+            raise ValidationError('Source must be a property of the target')
+        motivation = request_graph.value(s1, OA.motivatedBy, None, OA.commenting)
+        if motivation == OA.commenting:
+            if not isinstance(body, Literal):
+                raise ValidationError('Comment must be a literal')
+        elif motivation == OA.tagging:
+            if not isinstance(body, URIRef):
+                raise ValidationError('Tag must be a URI')
+        else:
+            raise ValidationError('Only commenting or tagging is supported at this time')
+
+        # Step 2: normalize the data. We modify the request_graph in place
+        # because this is convenient.
+        published = Literal(datetime.datetime.now())
+        creator = user_to_uriref(request.user)
+        request_graph.set((s1, RDF.type, EDPOPCOL.Annotation))
+        request_graph.set((s1, AS.published, published))
+        request_graph.set((s1, DCTERMS.creator, creator))
+
+        # Step 3: deanonymize all the blank nodes. We give the annotation
+        # subject a proper URI, then wrap the remaing ones with the bnode:
+        # scheme.
+        subject_node = URIRef(RDF_ANNOTATION_ROOT + uuid.uuid4().hex)
+        triples_with_subject = replace_node(request_graph, s1, subject_node)
+        triples_wo_blank = replace_blank_nodes_in_triples(triples_with_subject)
+        clean_triples = list(triples_wo_blank)
+
+        # Finish: store the final clean data and send them back to the client.
+        graph = Graph(identifier=ANNOTATION_GRAPH_IDENTIFIER)
+        quads = list(triples_to_quads(clean_triples, graph))
         # Get the existing graph from Blazegraph
         store = settings.RDFLIB_STORE
         store.addN(quads)
         store.commit()
-        graph = graph_from_triples(triples)
-        return Response(graph)
+        response_graph = graph_from_triples(clean_triples)
+        return Response(response_graph)
 
 
 class AnnotationEditView(RDFView):
-    parser_classes = (JSONParser,)
     renderer_classes = (JsonLdRenderer, TurtleRenderer)
     json_ld_context = JSON_LD_CONTEXT
 
@@ -142,29 +175,27 @@ class AnnotationEditView(RDFView):
         store.update(delete_annotation_update, initBindings={
             'annotations': ANNOTATION_GRAPH_IDENTIFIER,
             'annotation': id_uriref,
-        })
+        }, initNs=NS)
         store.commit()
         return Response(Graph())
 
     def put(self, request, **kwargs):
         # Allow editing of the body. Other properties cannot be edited.
         id_uriref = URIRef(kwargs.get("annotation"))
-        oa_has_body = Literal(request.data.get("oa:hasBody"))
-        as_updated = Literal(datetime.datetime.now())
+        graph = graph_from_request(request)
+        body = graph.value(id_uriref, OA.hasBody, None)
+
+        updated = Literal(datetime.datetime.now())
         store = settings.RDFLIB_STORE
         # Delete the current body
-        store.update(delete_annotation_body_update, initBindings={
+        store.update(update_annotation_body, initBindings={
             'annotations': ANNOTATION_GRAPH_IDENTIFIER,
             'annotation': id_uriref,
-        })
-        triples = [
-            (id_uriref, OA.hasBody, oa_has_body),
-            (id_uriref, AS.updated, as_updated),
-        ]
-        quads = list(triples_to_quads(triples, Graph(identifier=ANNOTATION_GRAPH_IDENTIFIER)))
-        store.addN(quads)
+            'body': body,
+            'updated': updated,
+        }, initNs=NS)
         store.commit()
-        graph = graph_from_triples(triples)
+        graph.set((id_uriref, AS.updated, updated))
         return Response(graph)
 
 
@@ -179,10 +210,8 @@ class AnnotationsPerTargetView(RDFView):
     def get_graph(self, request: Request, record: str, **kwargs) -> Graph:
         record_uri = URIRef(record)
         store = settings.RDFLIB_STORE
-        target_uris = sparql_multivalues([record_uri])
-        query = collection_records_query(target_uris=target_uris)
-        return graph_from_triples(store.query(query, initNs={
-            'rdfs': RDFS,
-        }, initBindings={
+        query = record_annotations_query
+        return graph_from_triples(store.query(query, initBindings={
             'annotations': ANNOTATION_GRAPH_IDENTIFIER,
-        }))
+            'record': record_uri,
+        }, initNs=NS))

--- a/backend/annotations/api_test.py
+++ b/backend/annotations/api_test.py
@@ -45,6 +45,7 @@ def test_edit_annotation(client, triplestore, django_test_user):
     uri = create_annotation(client, target, 'This is an annotation', django_test_user)
     client.put(f'/api/annotation/{quote_plus(uri)}/', {
         '@context': JSON_LD_CONTEXT,
+        '@id': uri,
         'oa:hasBody': 'This is an edited annotation'
     }, content_type='application/ld+json')
     body_triple = list(triplestore.triples((URIRef(uri), OA.hasBody, None)))[0][0]

--- a/backend/annotations/api_test.py
+++ b/backend/annotations/api_test.py
@@ -47,8 +47,7 @@ def test_list_annotations(client, triplestore, django_test_user):
     target = 'http://example.com/target'
     uri = create_annotation(client, target, 'This is an annotation', django_test_user)
     uri2 = create_annotation(client, target, 'This is another annotation', django_test_user)
-    response = client.get(f'/api/annotations-per-target/{quote_plus(target)}/', content_type='application/json')
+    response = client.get(f'/api/record-annotations/{quote_plus(target)}/', content_type='application/json')
     assert response.status_code == 200
     graph = response.data
     assert len(list(graph.triples((None, OA.hasTarget, URIRef(target))))) == 2
-

--- a/backend/annotations/api_test.py
+++ b/backend/annotations/api_test.py
@@ -4,50 +4,59 @@ from urllib.parse import quote_plus
 from rdflib import RDF, URIRef, Literal
 from triplestore.constants import EDPOPCOL, OA
 
+from .api import JSON_LD_CONTEXT
+
 
 @pytest.fixture
 def django_test_user(django_user_model):
     return django_user_model.objects.create_user(username='tester', password='secret')
 
 
-def annotation_exists_for_target(triplestore, target):
-    return len(list(triplestore.triples((None, OA.hasTarget, URIRef(target))))) == 1
+def annotation_exists_for_source(triplestore, source):
+    return len(list(triplestore.triples((None, OA.hasSource, URIRef(source))))) == 1
 
 
 def create_annotation(client, target, body, django_test_user) -> str:
     """Create an annotation through the API and return the URI."""
     data = {
+        "@context": JSON_LD_CONTEXT,
         "oa:hasTarget": target,
         "oa:hasBody": body
     }
     client.force_login(django_test_user)
-    response = client.post('/api/annotation/', data, content_type='application/json')
+    response = client.post('/api/annotation/', data, content_type='application/ld+json')
     assert response.status_code == 200
     uri = str(list(response.data.subjects(RDF.type, EDPOPCOL.Annotation))[0])
     return uri
 
 
 def test_create_delete_annotation(client, triplestore, django_test_user):
-    target = 'http://example.com/target'
+    source = 'http://example.com/source'
+    target = {'oa:hasSource': {'@id': source}}
     uri = create_annotation(client, target, 'This is an annotation', django_test_user)
-    assert annotation_exists_for_target(triplestore, target)
-    client.delete(f'/api/annotation/{quote_plus(uri)}/', content_type='application/json')
-    assert not annotation_exists_for_target(triplestore, target)
+    assert annotation_exists_for_source(triplestore, source)
+    client.delete(f'/api/annotation/{quote_plus(uri)}/')
+    assert not annotation_exists_for_source(triplestore, source)
 
 
 def test_edit_annotation(client, triplestore, django_test_user):
-    target = 'http://example.com/target'
+    source = 'http://example.com/source'
+    target = {'oa:hasSource': {'@id': source}}
     uri = create_annotation(client, target, 'This is an annotation', django_test_user)
-    client.put(f'/api/annotation/{quote_plus(uri)}/', {'oa:hasBody': 'This is an edited annotation'}, content_type='application/json')
+    client.put(f'/api/annotation/{quote_plus(uri)}/', {
+        '@context': JSON_LD_CONTEXT,
+        'oa:hasBody': 'This is an edited annotation'
+    }, content_type='application/ld+json')
     body_triple = list(triplestore.triples((URIRef(uri), OA.hasBody, None)))[0][0]
     assert body_triple[2] == Literal('This is an edited annotation')
 
 
 def test_list_annotations(client, triplestore, django_test_user):
-    target = 'http://example.com/target'
+    source = 'http://example.com/source'
+    target = {'oa:hasSource': {'@id': source}}
     uri = create_annotation(client, target, 'This is an annotation', django_test_user)
     uri2 = create_annotation(client, target, 'This is another annotation', django_test_user)
-    response = client.get(f'/api/record-annotations/{quote_plus(target)}/', content_type='application/json')
+    response = client.get(f'/api/record-annotations/{quote_plus(source)}/')
     assert response.status_code == 200
     graph = response.data
-    assert len(list(graph.triples((None, OA.hasTarget, URIRef(target))))) == 2
+    assert len(list(graph.triples((None, OA.hasSource, URIRef(source))))) == 2

--- a/backend/annotations/urls.py
+++ b/backend/annotations/urls.py
@@ -5,5 +5,5 @@ from . import api
 urlpatterns = [
     re_path(r'api/annotation/(?P<annotation>.+)/', api.AnnotationEditView.as_view(), name='annotation_edit'),
     path('api/annotation/', api.AnnotationView.as_view(), name='annotation'),
-    re_path(r'api/annotations-per-target/(?P<record>.+)/', api.AnnotationsPerTargetView.as_view(), name='annotations_per_target')
+    re_path(r'api/record-annotations/(?P<record>.+)/', api.AnnotationsPerTargetView.as_view(), name='record_annotations')
 ]

--- a/backend/triplestore/utils.py
+++ b/backend/triplestore/utils.py
@@ -92,6 +92,20 @@ def replace_blank_nodes_in_triples(triples: Triples) -> Triples:
     ) for s, p, o in triples)
 
 
+def replace_node(triples: Triples, old: Node, new: Node) -> Triples:
+    """Deep copy triples with all occurrences of old replaced by new."""
+
+    def apply_to_node(node: Node) -> Node:
+        if node == old:
+            return new
+        return node
+
+    def apply_to_triple(triple: Triple) -> Triple:
+        return tuple(map(apply_to_node, triple))
+
+    return map(apply_to_triple, triples)
+
+
 def triples_to_quads(triples: Triples, graph: Graph) -> Quads:
     """Convert all triples to quads according to a given named graph."""
     return ((s, p, o, graph) for s, p, o in triples)

--- a/backend/triplestore/utils_test.py
+++ b/backend/triplestore/utils_test.py
@@ -1,8 +1,14 @@
 from rdflib import BNode, Graph, URIRef, Literal
 from rdflib.namespace import RDF
 
-from .utils import union_graphs, replace_blank_node, \
-    replace_blank_nodes_in_triples, triples_to_quads, sparql_multivalues
+from .utils import (
+    replace_blank_node,
+    replace_blank_nodes_in_triples,
+    replace_node,
+    sparql_multivalues,
+    triples_to_quads,
+    union_graphs,
+)
 
 
 def blank_triple():
@@ -69,6 +75,20 @@ def test_replace_blank_nodes_in_triples_empty():
     triples = []
     result = replace_blank_nodes_in_triples(triples)
     assert list(result) == []
+
+
+def test_replace_node():
+    b1, b2, b3, b4 = (BNode() for x in range(4))
+    triples = [
+        (b1, b2, b3),
+        (b3, b1, b2),
+        (b2, b3, b1),
+    ]
+    assert list(replace_node(triples, b3, b4)) == [
+        (b1, b2, b4),
+        (b4, b1, b2),
+        (b2, b4, b1),
+    ]
 
 
 def test_triples_to_quads():

--- a/frontend/vre/annotation/annotation.edit.view.js
+++ b/frontend/vre/annotation/annotation.edit.view.js
@@ -35,12 +35,12 @@ export var AnnotationEditView = View.extend({
             confirmSelector,
             this.cancelTrash.bind(this),
         );
-        if (this.model.getAnnotationType() === 'tag') {
+        if (this.model.get('motivation') === 'oa:tagging') {
             glossary.on('update', this.render);
         }
     },
     render: function() {
-        if (this.model.getAnnotationType() === 'tag') {
+        if (this.model.get('motivation') === 'oa:tagging') {
             this.$('select').select2('destroy');
             this.$el.html(this.glossaryTemplate({
                 choices: glossary.toJSON(),
@@ -65,14 +65,14 @@ export var AnnotationEditView = View.extend({
         this.$el.popover('dispose');
         this.trashConfirmer.off();
         this.trashCanceller.off();
-        if (this.model.getAnnotationType() === 'tag') {
+        if (this.model.get('motivation') === 'oa:tagging') {
             this.$('select').select2('destroy');
         }
         return View.prototype.remove.call(this);
     },
     submit: function(event) {
         event.preventDefault();
-        if (this.model.getAnnotationType() === 'tag') {
+        if (this.model.get('motivation') === 'oa:tagging') {
             this.model.set("oa:hasBody", this.$('select').val());
         } else {
             this.model.set("oa:hasBody", this.$('textarea').val());

--- a/frontend/vre/annotation/annotation.edit.view.js
+++ b/frontend/vre/annotation/annotation.edit.view.js
@@ -49,7 +49,7 @@ export var AnnotationEditView = View.extend({
             this.$('select').select2({
                 dropdownParent: $('.modal-content'),
             });
-            var tag = this.model.get('glossary');
+            var tag = this.model.get('tagURL');
             if (tag) this.$('select').val(tag);
             this.$('select').trigger('change');
         } else {
@@ -72,7 +72,7 @@ export var AnnotationEditView = View.extend({
     submit: function(event) {
         event.preventDefault();
         if (this.model.get('motivation') === 'oa:tagging') {
-            this.model.set("glossary", this.$('select').val());
+            this.model.set("tagURL", this.$('select').val());
         } else {
             this.model.set("oa:hasBody", this.$('textarea').val());
         }

--- a/frontend/vre/annotation/annotation.edit.view.js
+++ b/frontend/vre/annotation/annotation.edit.view.js
@@ -54,7 +54,7 @@ export var AnnotationEditView = View.extend({
             this.$('select').trigger('change');
         } else {
             this.$el.html(this.template({
-                currentText: this.model.getBody(),
+                currentText: this.model.get('oa:hasBody'),
                 cid: this.cid,
             }));
         }

--- a/frontend/vre/annotation/annotation.edit.view.js
+++ b/frontend/vre/annotation/annotation.edit.view.js
@@ -49,9 +49,8 @@ export var AnnotationEditView = View.extend({
             this.$('select').select2({
                 dropdownParent: $('.modal-content'),
             });
-            if (this.model.getBody()) {
-                this.$('select').val(this.model.getBody()["@id"]);
-            }
+            var tag = this.model.get('glossary');
+            if (tag) this.$('select').val(tag);
             this.$('select').trigger('change');
         } else {
             this.$el.html(this.template({
@@ -73,7 +72,7 @@ export var AnnotationEditView = View.extend({
     submit: function(event) {
         event.preventDefault();
         if (this.model.get('motivation') === 'oa:tagging') {
-            this.model.set("oa:hasBody", this.$('select').val());
+            this.model.set("glossary", this.$('select').val());
         } else {
             this.model.set("oa:hasBody", this.$('textarea').val());
         }

--- a/frontend/vre/annotation/annotation.edit.view.js
+++ b/frontend/vre/annotation/annotation.edit.view.js
@@ -43,7 +43,7 @@ export var AnnotationEditView = View.extend({
         if (this.model.get('motivation') === 'oa:tagging') {
             this.$('select').select2('destroy');
             this.$el.html(this.glossaryTemplate({
-                choices: glossary.toJSON(),
+                choices: glossary.parse(glossary.toJSON()),
                 cid: this.cid,
             }));
             this.$('select').select2({

--- a/frontend/vre/annotation/annotation.edit.view.test.js
+++ b/frontend/vre/annotation/annotation.edit.view.test.js
@@ -50,7 +50,7 @@ describe('AnnotationEditView', function() {
         });
 
         it('saves input data to the model', function() {
-            assert(this.model.getBody() === 'green');
+            assert(this.model.get('oa:hasBody') === 'green');
         });
 
         it('triggers a "save" event', function() {

--- a/frontend/vre/annotation/annotation.model.js
+++ b/frontend/vre/annotation/annotation.model.js
@@ -21,7 +21,7 @@ export var Annotation = JsonLdModel.extend({
         if (this.get('motivation') === 'oa:commenting') {
             return this.getBody();
         } else if (this.get('motivation') === 'oa:tagging') {
-            var id = this.get('tagUrl');
+            var id = this.get('tagURL');
             return glossary.get(id).get('skos:prefLabel');
         }
     },
@@ -37,7 +37,7 @@ export var Annotation = JsonLdModel.extend({
     // Fields that are normally nested in JSON-LD, but get hoisted to the
     // top-level `attributes` for more convenient access. See the overridden
     // `parse` and `toJSON` methods below.
-    flatFields: ['motivation', 'glossary', 'oa:hasSource', 'edpopcol:field', 'edpopcol:originalText'],
+    flatFields: ['motivation', 'tagURL', 'oa:hasSource', 'edpopcol:field', 'edpopcol:originalText'],
     parse: function(response, options) {
         var anno = parent(Annotation.prototype)
             .parse.call(this, response, options),
@@ -46,7 +46,7 @@ export var Annotation = JsonLdModel.extend({
             body = anno['oa:hasBody'],
             target = anno['oa:hasTarget'];
         if (motivation) flat.motivation = motivation['@id'];
-        if (body && body['@id']) flat.glossary = body['@id'];
+        if (body && body['@id']) flat.tagURL = body['@id'];
         if (target) {
             var source = target['oa:hasSource'],
                 selector = target['oa:hasSelector'];
@@ -64,7 +64,7 @@ export var Annotation = JsonLdModel.extend({
         var jsonld = parent(Annotation.prototype).
             toJSON.call(this, options),
             flatMotivation = jsonld.motivation,
-            flatGlossary = jsonld.glossary,
+            flatTagURL = jsonld.tagURL,
             target = jsonld['oa:hasTarget'] || {},
             selector = target['oa:hasSelector'] || {},
             flatSource = jsonld['oa:hasSource'],
@@ -76,7 +76,7 @@ export var Annotation = JsonLdModel.extend({
         if (flatSource) target['oa:hasSource'] = {'@id': flatSource};
         if (flatSelector) target['oa:hasSelector'] = selector;
         if (flatSource || flatSelector) jsonld['oa:hasTarget'] = target;
-        if (flatGlossary) jsonld['oa:hasBody'] = {'@id': flatGlossary};
+        if (flatTagURL) jsonld['oa:hasBody'] = {'@id': flatTagURL};
         if (flatMotivation) jsonld['oa:motivatedBy'] = {'@id': flatMotivation};
         _.each(this.flatFields, stripAttribute(jsonld));
         return jsonld;

--- a/frontend/vre/annotation/annotation.model.js
+++ b/frontend/vre/annotation/annotation.model.js
@@ -1,18 +1,9 @@
-import {
-    getDateTimeLiteral,
-    JsonLdModel,
-    JsonLdNestedCollection,
-    jsonLdSync,
-    priorMethod,
-} from "../utils/jsonld.model";
+import {getDateTimeLiteral, JsonLdModel, JsonLdNestedCollection} from "../utils/jsonld.model";
 import {UserLd} from "../user/user.ld.model";
 import {glossary} from "../utils/glossary";
 
 export var Annotation = JsonLdModel.extend({
     urlRoot: '/api/annotation/',
-    // TODO: remove the next line after adapting the backend so that it can
-    // process JSON-LD as such.
-    sync: priorMethod(JsonLdModel.prototype, 'sync', jsonLdSync),
     getBody: function() {
         return this.get('oa:hasBody');
     },
@@ -57,9 +48,6 @@ export var Annotation = JsonLdModel.extend({
 
 export var Annotations = JsonLdNestedCollection.extend({
     model: Annotation,
-    // TODO: remove the next line after adapting the backend so that it can
-    // process JSON-LD as such.
-    sync: priorMethod(JsonLdModel.prototype, 'sync', jsonLdSync),
     initialize: function(model, options) {
         _.assign(this, _.pick(options, ['target']));
         this.url = `/api/record-annotations/${encodeURIComponent(this.target)}/`;

--- a/frontend/vre/annotation/annotation.model.js
+++ b/frontend/vre/annotation/annotation.model.js
@@ -98,8 +98,21 @@ export var Annotation = JsonLdModel.extend({
     },
 });
 
+/**
+ * Collection of instances of {@link Annotation}.
+ *
+ * @class
+ */
 export var Annotations = JsonLdNestedCollection.extend({
     model: Annotation,
+    /**
+     * @name Annotations#target
+     * @member {string}
+     * @summary The `target` of an Annotations collection is the id of the
+     * {@link Record} that all annotations in the collection are about. This
+     * means that it becomes the `oa:hasSource` (NOT the `oa:hasTarget`!) in the
+     * JSON-LD representation.
+     */
     initialize: function(model, options) {
         _.assign(this, _.pick(options, ['target']));
         this.url = `/api/record-annotations/${encodeURIComponent(this.target)}/`;

--- a/frontend/vre/annotation/annotation.model.js
+++ b/frontend/vre/annotation/annotation.model.js
@@ -1,9 +1,9 @@
 import _ from 'lodash';
 import { parent } from '@uu-cdh/backbone-collection-transformers/src/inheritance.js';
 
-import {getDateTimeLiteral, JsonLdModel, JsonLdNestedCollection} from "../utils/jsonld.model";
-import {UserLd} from "../user/user.ld.model";
-import {glossary} from "../utils/glossary";
+import {getDateTimeLiteral, JsonLdModel, JsonLdNestedCollection} from '../utils/jsonld.model';
+import {UserLd} from '../user/user.ld.model';
+import {glossary} from '../utils/glossary';
 
 // Helper function for removing multiple properties from an object in iteration.
 function stripAttribute(container) {
@@ -32,6 +32,7 @@ function stripAttribute(container) {
  */
 export var Annotation = JsonLdModel.extend({
     urlRoot: '/api/annotation/',
+
     getDisplayText: function() {
         if (this.get('motivation') === 'oa:commenting') {
             return this.get('oa:hasBody');
@@ -40,19 +41,24 @@ export var Annotation = JsonLdModel.extend({
             return glossary.get(id).get('skos:prefLabel');
         }
     },
+
     getPublishedDate: function() {
         return getDateTimeLiteral(this.get('as:published'));
     },
+
     getUpdatedDate: function() {
         return getDateTimeLiteral(this.get('as:updated'));
     },
+
     getAuthor: function() {
         return new UserLd(this.get('dcterms:creator'));
     },
+
     // Fields that are normally nested in JSON-LD, but get hoisted to the
     // top-level `attributes` for more convenient access. See the overridden
     // `parse` and `toJSON` methods below.
     flatFields: ['motivation', 'tagURL', 'oa:hasSource', 'edpopcol:field', 'edpopcol:originalText'],
+
     parse: function(response, options) {
         var anno = parent(Annotation.prototype)
             .parse.call(this, response, options),
@@ -75,6 +81,7 @@ export var Annotation = JsonLdModel.extend({
         }
         return _.assign(flat, anno);
     },
+
     toJSON: function(options) {
         var jsonld = parent(Annotation.prototype).
             toJSON.call(this, options),
@@ -105,6 +112,7 @@ export var Annotation = JsonLdModel.extend({
  */
 export var Annotations = JsonLdNestedCollection.extend({
     model: Annotation,
+
     /**
      * @name Annotations#target
      * @member {string}
@@ -113,12 +121,14 @@ export var Annotations = JsonLdNestedCollection.extend({
      * means that it becomes the `oa:hasSource` (NOT the `oa:hasTarget`!) in the
      * JSON-LD representation.
      */
+
     initialize: function(model, options) {
         _.assign(this, _.pick(options, ['target']));
         this.url = `/api/record-annotations/${encodeURIComponent(this.target)}/`;
         this.on('remove', this.deleteAnnotation);
     },
+
     deleteAnnotation: function(annotation) {
         annotation.destroy();
-    }
-})
+    },
+});

--- a/frontend/vre/annotation/annotation.model.js
+++ b/frontend/vre/annotation/annotation.model.js
@@ -1,6 +1,16 @@
+import _ from 'lodash';
+import { parent } from '@uu-cdh/backbone-collection-transformers/src/inheritance.js';
+
 import {getDateTimeLiteral, JsonLdModel, JsonLdNestedCollection} from "../utils/jsonld.model";
 import {UserLd} from "../user/user.ld.model";
 import {glossary} from "../utils/glossary";
+
+// Helper function for removing multiple properties from an object in iteration.
+function stripAttribute(container) {
+    return function(name) {
+        delete container[name];
+    };
+}
 
 export var Annotation = JsonLdModel.extend({
     urlRoot: '/api/annotation/',
@@ -36,6 +46,53 @@ export var Annotation = JsonLdModel.extend({
             console.warn('Unsupported annotation type: ' + motivationId);
             return null;
         }
+    },
+    // Fields that are normally nested in JSON-LD, but get hoisted to the
+    // top-level `attributes` for more convenient access. See the overridden
+    // `parse` and `toJSON` methods below.
+    flatFields: ['motivation', 'glossary', 'oa:hasSource', 'edpopcol:field', 'edpopcol:originalText'],
+    parse: function(response, options) {
+        var anno = parent(Annotation.prototype)
+            .parse.call(this, response, options),
+            flat = {},
+            motivation = anno['oa:motivatedBy'],
+            body = anno['oa:hasBody'],
+            target = anno['oa:hasTarget'];
+        if (motivation) flat.motivation = motivation['@id'];
+        if (body && body['@id']) flat.glossary = body['@id'];
+        if (target) {
+            var source = target['oa:hasSource'],
+                selector = target['oa:hasSelector'];
+            if (source) flat['oa:hasSource'] = source['@id'];
+            if (selector) {
+                var field = selector['edpopcol:field'],
+                    text = selector['edpopcol:originalText'];
+                if (field) flat['edpopcol:field'] = field['@id'];
+                if (text) flat['edpopcol:originalText'] = text;
+            }
+        }
+        return _.assign(flat, anno);
+    },
+    toJSON: function(options) {
+        var jsonld = parent(Annotation.prototype).
+            toJSON.call(this, options),
+            flatMotivation = jsonld.motivation,
+            flatGlossary = jsonld.glossary,
+            target = jsonld['oa:hasTarget'] || {},
+            selector = target['oa:hasSelector'] || {},
+            flatSource = jsonld['oa:hasSource'],
+            flatField = jsonld['edpopcol:field'],
+            flatText = jsonld['edpopcol:originalText'];
+        if (flatField) selector['edpopcol:field'] = {'@id': flatField};
+        if (flatText) selector['edpopcol:originalText'] = flatText;
+        if (flatField || flatText) var flatSelector = true;
+        if (flatSource) target['oa:hasSource'] = {'@id': flatSource};
+        if (flatSelector) target['oa:hasSelector'] = selector;
+        if (flatSource || flatSelector) jsonld['oa:hasTarget'] = target;
+        if (flatGlossary) jsonld['oa:hasBody'] = {'@id': flatGlossary};
+        if (flatMotivation) jsonld['oa:motivatedBy'] = {'@id': flatMotivation};
+        _.each(this.flatFields, stripAttribute(jsonld));
+        return jsonld;
     },
 });
 

--- a/frontend/vre/annotation/annotation.model.js
+++ b/frontend/vre/annotation/annotation.model.js
@@ -83,8 +83,8 @@ export var Annotation = JsonLdModel.extend({
     },
 
     toJSON: function(options) {
-        var jsonld = parent(Annotation.prototype).
-            toJSON.call(this, options),
+        var jsonld = parent(Annotation.prototype)
+            .toJSON.call(this, options),
             flatMotivation = jsonld.motivation,
             flatTagURL = jsonld.tagURL,
             target = jsonld['oa:hasTarget'] || {},

--- a/frontend/vre/annotation/annotation.model.js
+++ b/frontend/vre/annotation/annotation.model.js
@@ -37,13 +37,6 @@ export var Annotation = JsonLdModel.extend({
             return null;
         }
     },
-    url: function() {
-        if (this.isNew()) {
-            return '/api/annotation/';
-        } else {
-            return '/api/annotation/' + encodeURIComponent(this.id) + '/';
-        }
-    },
 });
 
 export var Annotations = JsonLdNestedCollection.extend({

--- a/frontend/vre/annotation/annotation.model.js
+++ b/frontend/vre/annotation/annotation.model.js
@@ -18,9 +18,9 @@ export var Annotation = JsonLdModel.extend({
         return this.get('oa:hasBody');
     },
     getDisplayText: function() {
-        if (this.getAnnotationType() === 'comment') {
+        if (this.get('motivation') === 'oa:commenting') {
             return this.getBody();
-        } else if (this.getAnnotationType() === 'tag') {
+        } else if (this.get('motivation') === 'oa:tagging') {
             var id = this.getBody();
             return glossary.get(id).get('skos:prefLabel');
         }
@@ -33,19 +33,6 @@ export var Annotation = JsonLdModel.extend({
     },
     getAuthor: function() {
         return new UserLd(this.get('dcterms:creator'));
-    },
-    getAnnotationType: function() {
-        var motivation = this.get('oa:motivatedBy');
-        if (!motivation) return null;
-        var motivationId = motivation["@id"];
-        if (motivationId === 'oa:commenting') {
-            return 'comment';
-        } else if (motivationId === 'oa:tagging') {
-            return 'tag';
-        } else {
-            console.warn('Unsupported annotation type: ' + motivationId);
-            return null;
-        }
     },
     // Fields that are normally nested in JSON-LD, but get hoisted to the
     // top-level `attributes` for more convenient access. See the overridden

--- a/frontend/vre/annotation/annotation.model.js
+++ b/frontend/vre/annotation/annotation.model.js
@@ -12,6 +12,24 @@ function stripAttribute(container) {
     };
 }
 
+/**
+ * Backbone.Model representation of a Web Annotation to an EDPOP record.
+ *
+ * This model stores and synchronizes an annotation in compacted JSON-LD format.
+ * The Web Annotation data model is highly nested, which is inconvenient in a
+ * presentation and editing context. To remedy this, nested properties of
+ * interest are copied to the root `attributes` object during parsing. They are
+ * re-nested before being sent to the backend. Client code should read and edit
+ * these root-level attributes, rather than their standard nested paths (in parentheses):
+ *
+ * motivation            ([oa:motivatedBy][@id])
+ * tagURL                ([oa:hasBody][@id] if motivation === oa:tagging)
+ * oa:hasSource          ([oa:hasTarget][oa:hasSource][@id])
+ * edpopcol:field        ([oa:hasTarget][oa:hasSelector][edpopcol:field][@id])
+ * edpopcol:originalText ([oa:hasTarget][oa:hasSelector][edpopcol:originalText])
+ *
+ * @class
+ */
 export var Annotation = JsonLdModel.extend({
     urlRoot: '/api/annotation/',
     getBody: function() {

--- a/frontend/vre/annotation/annotation.model.js
+++ b/frontend/vre/annotation/annotation.model.js
@@ -21,7 +21,7 @@ export var Annotation = JsonLdModel.extend({
         if (this.get('motivation') === 'oa:commenting') {
             return this.getBody();
         } else if (this.get('motivation') === 'oa:tagging') {
-            var id = this.getBody();
+            var id = this.get('tagUrl');
             return glossary.get(id).get('skos:prefLabel');
         }
     },

--- a/frontend/vre/annotation/annotation.model.js
+++ b/frontend/vre/annotation/annotation.model.js
@@ -62,7 +62,7 @@ export var Annotations = JsonLdNestedCollection.extend({
     sync: priorMethod(JsonLdModel.prototype, 'sync', jsonLdSync),
     initialize: function(model, options) {
         _.assign(this, _.pick(options, ['target']));
-        this.url = `/api/annotations-per-target/${encodeURIComponent(this.target)}/`;
+        this.url = `/api/record-annotations/${encodeURIComponent(this.target)}/`;
         this.on('remove', this.deleteAnnotation);
     },
     deleteAnnotation: function(annotation) {

--- a/frontend/vre/annotation/annotation.model.js
+++ b/frontend/vre/annotation/annotation.model.js
@@ -32,12 +32,9 @@ function stripAttribute(container) {
  */
 export var Annotation = JsonLdModel.extend({
     urlRoot: '/api/annotation/',
-    getBody: function() {
-        return this.get('oa:hasBody');
-    },
     getDisplayText: function() {
         if (this.get('motivation') === 'oa:commenting') {
-            return this.getBody();
+            return this.get('oa:hasBody');
         } else if (this.get('motivation') === 'oa:tagging') {
             var id = this.get('tagURL');
             return glossary.get(id).get('skos:prefLabel');

--- a/frontend/vre/annotation/annotation.model.test.js
+++ b/frontend/vre/annotation/annotation.model.test.js
@@ -41,7 +41,7 @@ const serverMod = {
 const clientMod = {
     '@id': serverMod['@id'],
     motivation: serverMod['oa:motivatedBy']['@id'],
-    glossary: serverMod['oa:hasBody']['@id'],
+    tagURL: serverMod['oa:hasBody']['@id'],
     'oa:hasSource': serverMod['oa:hasTarget']['oa:hasSource']['@id'],
     'edpopcol:field': serverMod['oa:hasTarget']['oa:hasSelector']['edpopcol:field']['@id'],
     'edpopcol:originalText': serverMod['oa:hasTarget']['oa:hasSelector']['edpopcol:originalText'],

--- a/frontend/vre/annotation/annotation.model.test.js
+++ b/frontend/vre/annotation/annotation.model.test.js
@@ -1,0 +1,95 @@
+import assert from 'assert';
+import sinon from 'sinon';
+
+import { Annotation } from './annotation.model';
+
+const deepAnnotation = {
+    '@id': 'http://example.com/anno',
+    'oa:motivatedBy': {'@id': 'oa:commenting'},
+    'oa:hasBody': 'awesome',
+    'oa:hasTarget': {
+        'oa:hasSource': {'@id': 'http://example.com/source'},
+        'oa:hasSelector': {
+            'edpopcol:field': {'@id': 'edpoprec:title'},
+            'edpopcol:originalText': 'fabulous',
+        },
+    },
+};
+
+const flatAnnotation = {
+    '@id': deepAnnotation['@id'],
+    motivation: deepAnnotation['oa:motivatedBy']['@id'],
+    'oa:hasBody': deepAnnotation['oa:hasBody'],
+    'oa:hasSource': deepAnnotation['oa:hasTarget']['oa:hasSource']['@id'],
+    'edpopcol:field': deepAnnotation['oa:hasTarget']['oa:hasSelector']['edpopcol:field']['@id'],
+    'edpopcol:originalText': deepAnnotation['oa:hasTarget']['oa:hasSelector']['edpopcol:originalText'],
+};
+
+const serverMod = {
+    '@id': 'http://example.com/anno2',
+    'oa:motivatedBy': {'@id': 'oa:tagging'},
+    'oa:hasBody': {'@id': 'http://example.com/almanac'},
+    'oa:hasTarget': {
+        'oa:hasSource': {'@id': 'http://example.com/source'},
+        'oa:hasSelector': {
+            'edpopcol:field': {'@id': 'edpoprec:notes'},
+            'edpopcol:originalText': 'pictures!',
+        },
+    },
+};
+
+const clientMod = {
+    '@id': serverMod['@id'],
+    motivation: serverMod['oa:motivatedBy']['@id'],
+    glossary: serverMod['oa:hasBody']['@id'],
+    'oa:hasSource': serverMod['oa:hasTarget']['oa:hasSource']['@id'],
+    'edpopcol:field': serverMod['oa:hasTarget']['oa:hasSelector']['edpopcol:field']['@id'],
+    'edpopcol:originalText': serverMod['oa:hasTarget']['oa:hasSelector']['edpopcol:originalText'],
+};
+
+describe('Annotation model', () => {
+    let model;
+
+    beforeEach(() => {
+        model = new Annotation;
+    });
+
+    afterEach(() => {
+        model.clear().off().stopListening();
+    });
+
+    it('parses deep JSON-LD into a convenient flat structure', () => {
+        const parsed = model.parse(deepAnnotation);
+        sinon.assert.match(parsed, flatAnnotation);
+    });
+
+    it('preserves the nested structure when parsing', () => {
+        const parsed = model.parse(deepAnnotation);
+        sinon.assert.match(parsed, deepAnnotation);
+    });
+
+    it('serializes the flat structure back to deep', () => {
+        model.set(flatAnnotation);
+        const serialized = model.toJSON();
+        assert.deepStrictEqual(serialized, deepAnnotation);
+    });
+
+    it('updates with server side changes', () => {
+        model.set(flatAnnotation);
+        // by parsing first, we emulate the behaviour of the sync methods
+        model.set(model.parse(serverMod)),
+        sinon.assert.match(model.attributes, clientMod);
+    });
+
+    it('updates the server with client side changes', () => {
+        // we pretend that the attributes were originally set by the server
+        model.set(model.parse(deepAnnotation)),
+        sinon.assert.match(model.attributes, deepAnnotation);
+        sinon.assert.match(model.attributes, flatAnnotation);
+        // now, we override on the client side
+        model.set(clientMod);
+        // finally, toJSON tells us what will be sent to the server
+        const serialized = model.toJSON();
+        assert.deepStrictEqual(serialized, serverMod);
+    });
+});

--- a/frontend/vre/annotation/comment.view.js
+++ b/frontend/vre/annotation/comment.view.js
@@ -27,7 +27,7 @@ export var CommentView = View.extend({
         var author = this.model.getAuthor();
         Object.assign(templateData, {
             isFieldAnnotation: this.fieldAnnotation,
-            isTag: this.model.getAnnotationType() === 'tag',
+            isTag: this.model.get('motivation') === 'oa:tagging',
             displayText: this.model.getDisplayText(),
             author: (author ? author.getUsername() : null),
             publishedDate: (publishedDate ? publishedDate.toLocaleString() : null),

--- a/frontend/vre/field/field.view.js
+++ b/frontend/vre/field/field.view.js
@@ -52,7 +52,7 @@ export var FieldView = AnnotatableView.extend({
         var fieldId = this.model.get('key');
         var fieldContents = this.model.get('value');
         var attributes = {
-            "oa:hasTarget": this.collection.underlying.target,
+            "oa:hasSource": this.collection.underlying.target,
             "edpopcol:field": fieldId,
             "motivation": "oa:commenting",
         };

--- a/frontend/vre/field/field.view.js
+++ b/frontend/vre/field/field.view.js
@@ -51,11 +51,14 @@ export var FieldView = AnnotatableView.extend({
         event.preventDefault();
         var fieldId = this.model.get('key');
         var fieldContents = this.model.get('value');
-        this.edit(new Annotation({
+        var attributes = {
             "oa:hasTarget": this.collection.underlying.target,
             "edpopcol:field": fieldId,
-            "edpopcol:originalText": (fieldContents ? fieldContents['edpoprec:originalText'] : null),
-            "oa:motivatedBy": {"@id": "oa:commenting"},
-        }));
+            "motivation": "oa:commenting",
+        };
+        if (fieldContents) {
+            attributes['edpopcol:originalText'] = fieldContents['edpoprec:originalText'];
+        }
+        this.edit(new Annotation(attributes));
     },
 });

--- a/frontend/vre/field/field.view.js
+++ b/frontend/vre/field/field.view.js
@@ -53,8 +53,8 @@ export var FieldView = AnnotatableView.extend({
         var fieldContents = this.model.get('value');
         this.edit(new Annotation({
             "oa:hasTarget": this.collection.underlying.target,
-            "edpopcol:selectField": fieldId,
-            "edpopcol:selectOriginalText": (fieldContents ? fieldContents['edpoprec:originalText'] : null),
+            "edpopcol:field": fieldId,
+            "edpopcol:originalText": (fieldContents ? fieldContents['edpoprec:originalText'] : null),
             "oa:motivatedBy": {"@id": "oa:commenting"},
         }));
     },

--- a/frontend/vre/field/record.annotations.view.js
+++ b/frontend/vre/field/record.annotations.view.js
@@ -27,14 +27,14 @@ export var RecordAnnotationsView = AnnotatableView.extend({
     editEmpty: function() {
         this.edit(new Annotation({
             "oa:hasTarget": this.collection.underlying.target,
-            "oa:motivatedBy": {"@id": "oa:commenting"},
+            "motivation": "oa:commenting",
         }));
     },
 
     editEmptyTag: function() {
         this.edit(new Annotation({
             "oa:hasTarget": this.collection.underlying.target,
-            "oa:motivatedBy": {"@id": "oa:tagging"},
+            "motivation": "oa:tagging",
         }))
     },
 });

--- a/frontend/vre/field/record.annotations.view.js
+++ b/frontend/vre/field/record.annotations.view.js
@@ -26,14 +26,14 @@ export var RecordAnnotationsView = AnnotatableView.extend({
 
     editEmpty: function() {
         this.edit(new Annotation({
-            "oa:hasTarget": this.collection.underlying.target,
+            "oa:hasSource": this.collection.underlying.target,
             "motivation": "oa:commenting",
         }));
     },
 
     editEmptyTag: function() {
         this.edit(new Annotation({
-            "oa:hasTarget": this.collection.underlying.target,
+            "oa:hasSource": this.collection.underlying.target,
             "motivation": "oa:tagging",
         }))
     },

--- a/frontend/vre/field/record.fields.view.js
+++ b/frontend/vre/field/record.fields.view.js
@@ -6,10 +6,8 @@ import {FieldView} from "./field.view";
 function annotationMatchesField(model, targetField) {
     return function(annotation) {
         var field = annotation.get('edpopcol:field');
+        if (field !== targetField) return false;
         var originalText = annotation.get('edpopcol:originalText');
-        if (!field) return false;
-        var fieldId = field["@id"];
-        if (fieldId !== targetField) return false;
         return !originalText || originalText === model.get('value')["edpoprec:originalText"];
     }
 }

--- a/frontend/vre/field/record.fields.view.js
+++ b/frontend/vre/field/record.fields.view.js
@@ -3,14 +3,14 @@ import { FilteredCollection } from "../utils/filtered.collection";
 import fieldListTemplate from "./record.fields.view.mustache";
 import {FieldView} from "./field.view";
 
-function annotationMatchesField(model, field) {
+function annotationMatchesField(model, targetField) {
     return function(annotation) {
-        var selectField = annotation.get('edpopcol:selectField');
-        var selectOriginalText = annotation.get('edpopcol:selectOriginalText');
-        if (!selectField) return false;
-        var selectFieldId = selectField["@id"];
-        if (selectFieldId !== field) return false;
-        return !selectOriginalText || selectOriginalText === model.get('value')["edpoprec:originalText"];
+        var field = annotation.get('edpopcol:field');
+        var originalText = annotation.get('edpopcol:originalText');
+        if (!field) return false;
+        var fieldId = field["@id"];
+        if (fieldId !== targetField) return false;
+        return !originalText || originalText === model.get('value')["edpoprec:originalText"];
     }
 }
 

--- a/frontend/vre/record/record.detail.view.js
+++ b/frontend/vre/record/record.detail.view.js
@@ -76,7 +76,7 @@ export var RecordDetailView = CompositeView.extend({
             model: model,
         });
         var recordAnnotations = FilteredCollection(model.annotations, (annotation) => {
-            return !annotation.get('edpopcol:selectField');
+            return !annotation.get('edpopcol:field');
         });
         this.annotationsView = new RecordAnnotationsView({
             collection: recordAnnotations,


### PR DESCRIPTION
This closes #294, which I was able to do faster than I expected.

I previously described an approach for the frontend model based on `get`/`set` accessors. I changed my mind about that, because that approach would not trigger the conventional `change` events unless I would trigger them manually from the accessors. It also meant that idiomatic `annotation.get()` and `annotation.set()` would still be cumbersome. Instead, I went with the `parse`/`toJSON` approach that I already described in #294, so that everything could stay conventional and idiomatic.

The approach I took has a different disadvantage, which I consider the lesser evil. The model stores both the faithful, nested JSON-LD representation of the annotation, in order to prevent information loss, as well as a partial flattened representation for convenience. Where information is duplicated, users of the model class are expected to always access and edit the flattened copy of the property rather than the nested copy. This *could* be a footgun, if a user is knowledgeable about the web annotation vocabulary and JSON-LD but not about the `Annotation` model class. It also introduces some inconsistency in the naming of the attributes,  as you will see when you read the JsDoc comments in the `frontend/vre/annotation/annotation.model.js` module. I'm open to suggestions for modifications on this front.

Other changes:

- rewrote of the backend API, not only to reflect the structural changes but also to ingest proper JSON-LD instead of plain JSON
- avoiding the word "target" wherever `oa:hasSource` is intended, including in one of the backend API routes (with one exception for `Annotations#target`; this could perhaps be renamed to `#record`)
- removed or simplified a lot of code in the frontend
- renamed the selector fields to reflect the proposed changes in CentreForDigitalHumanities/edpop-collection-ontology#7
- fixed a previously unnoticed bug that I caused in #287, where the tag editor could no longer list the genres from the glossary