### PR TITLE
Project-bound annotations

### DIFF
--- a/backend/annotations/api.py
+++ b/backend/annotations/api.py
@@ -10,6 +10,7 @@ from rdf.utils import graph_from_triples
 from rdf.renderers import TurtleRenderer, JsonLdRenderer
 
 from accounts.utils import user_to_uriref
+from collect.serializers import check_user_project_authorization
 from triplestore.constants import EDPOPREC, OA, AS, EDPOPCOL
 from triplestore.utils import (
     replace_blank_nodes_in_triples,
@@ -100,9 +101,31 @@ where {
 }
 '''
 
+annotation_in_project_query = '''
+select ?project
+where {
+  graph ?annotations {
+    ?annotation as:context ?project .
+  }
+}
+'''
+
 
 def create_annotation_subject_node() -> URIRef:
     return URIRef(RDF_ANNOTATION_ROOT + uuid.uuid4().hex)
+
+
+def check_user_annotation_authorization(user, annotation):
+    store = settings.RDFLIB_STORE
+    projects = [binds.project for binds in store.query(
+        annotation_in_project_query,
+        initNs=NS,
+        initBindings={
+            'annotations': ANNOTATION_GRAPH_IDENTIFIER,
+            'annotation': annotation,
+        })]
+    assert len(projects) == 1
+    check_user_project_authorization(user, projects[0])
 
 
 class AnnotationView(RDFView):
@@ -116,6 +139,7 @@ class AnnotationView(RDFView):
         bodies = list(request_graph.subject_objects(OA.hasBody))
         targets = list(request_graph.subject_objects(OA.hasTarget))
         sources = list(request_graph.subject_objects(OA.hasSource))
+        contexts = list(request_graph.subject_objects(AS.context))
         if len(bodies) == 1:
             s1, body = bodies[0]
         else:
@@ -128,8 +152,13 @@ class AnnotationView(RDFView):
             s3, source = sources[0]
         else:
             raise ValidationError('Needs exactly one source')
-        if s1 != s2:
-            raise ValidationError('Body and target must be annotation properties')
+        if len(contexts) == 1:
+            s4, context = contexts[0]
+        else:
+            raise ValidationError('Needs exactly one context')
+        if s1 != s2 or s1 != s4:
+            raise ValidationError('Body, target and context must be annotation properties')
+        check_user_project_authorization(request.user, context)
         if s3 != target:
             raise ValidationError('Source must be a property of the target')
         motivation = request_graph.value(s1, OA.motivatedBy, None, OA.commenting)
@@ -176,6 +205,7 @@ class AnnotationEditView(RDFView):
     def delete(self, request, **kwargs):
         id_uriref = URIRef(kwargs.get("annotation"))
         store = settings.RDFLIB_STORE
+        check_user_annotation_authorization(request.user, id_uriref)
         store.update(delete_annotation_update, initBindings={
             'annotations': ANNOTATION_GRAPH_IDENTIFIER,
             'annotation': id_uriref,
@@ -186,11 +216,12 @@ class AnnotationEditView(RDFView):
     def put(self, request, **kwargs):
         # Allow editing of the body. Other properties cannot be edited.
         id_uriref = URIRef(kwargs.get("annotation"))
+        store = settings.RDFLIB_STORE
+        check_user_annotation_authorization(request.user, id_uriref)
+
         graph = graph_from_request(request)
         body = graph.value(id_uriref, OA.hasBody, None)
-
         updated = Literal(datetime.datetime.now())
-        store = settings.RDFLIB_STORE
         # Delete the current body
         store.update(update_annotation_body, initBindings={
             'annotations': ANNOTATION_GRAPH_IDENTIFIER,

--- a/backend/annotations/api_test.py
+++ b/backend/annotations/api_test.py
@@ -1,15 +1,9 @@
-import pytest
 from urllib.parse import quote_plus
 
 from rdflib import RDF, URIRef, Literal
 from triplestore.constants import EDPOPCOL, OA
 
 from .api import JSON_LD_CONTEXT
-
-
-@pytest.fixture
-def django_test_user(django_user_model):
-    return django_user_model.objects.create_user(username='tester', password='secret')
 
 
 def annotation_exists_for_source(triplestore, source):

--- a/backend/annotations/api_test.py
+++ b/backend/annotations/api_test.py
@@ -10,12 +10,13 @@ def annotation_exists_for_source(triplestore, source):
     return len(list(triplestore.triples((None, OA.hasSource, URIRef(source))))) == 1
 
 
-def create_annotation(client, target, body, django_test_user) -> str:
+def create_annotation(client, target, body, django_test_user, project) -> str:
     """Create an annotation through the API and return the URI."""
     data = {
         "@context": JSON_LD_CONTEXT,
         "oa:hasTarget": target,
-        "oa:hasBody": body
+        "oa:hasBody": body,
+        "as:context": project.uri,
     }
     client.force_login(django_test_user)
     response = client.post('/api/annotation/', data, content_type='application/ld+json')
@@ -24,19 +25,21 @@ def create_annotation(client, target, body, django_test_user) -> str:
     return uri
 
 
-def test_create_delete_annotation(client, triplestore, django_test_user):
+def test_create_delete_annotation(client, triplestore, django_test_user, project):
     source = 'http://example.com/source'
     target = {'oa:hasSource': {'@id': source}}
-    uri = create_annotation(client, target, 'This is an annotation', django_test_user)
+    uri = create_annotation(client, target, 'This is an annotation',
+                            django_test_user, project)
     assert annotation_exists_for_source(triplestore, source)
     client.delete(f'/api/annotation/{quote_plus(uri)}/')
     assert not annotation_exists_for_source(triplestore, source)
 
 
-def test_edit_annotation(client, triplestore, django_test_user):
+def test_edit_annotation(client, triplestore, django_test_user, project):
     source = 'http://example.com/source'
     target = {'oa:hasSource': {'@id': source}}
-    uri = create_annotation(client, target, 'This is an annotation', django_test_user)
+    uri = create_annotation(client, target, 'This is an annotation',
+                            django_test_user, project)
     client.put(f'/api/annotation/{quote_plus(uri)}/', {
         '@context': JSON_LD_CONTEXT,
         '@id': uri,
@@ -46,11 +49,13 @@ def test_edit_annotation(client, triplestore, django_test_user):
     assert body_triple[2] == Literal('This is an edited annotation')
 
 
-def test_list_annotations(client, triplestore, django_test_user):
+def test_list_annotations(client, triplestore, django_test_user, project):
     source = 'http://example.com/source'
     target = {'oa:hasSource': {'@id': source}}
-    uri = create_annotation(client, target, 'This is an annotation', django_test_user)
-    uri2 = create_annotation(client, target, 'This is another annotation', django_test_user)
+    uri = create_annotation(client, target, 'This is an annotation',
+                            django_test_user, project)
+    uri2 = create_annotation(client, target, 'This is another annotation',
+                             django_test_user, project)
     response = client.get(f'/api/record-annotations/{quote_plus(source)}/')
     assert response.status_code == 200
     graph = response.data

--- a/backend/annotations/conftest.py
+++ b/backend/annotations/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture
+def django_test_user(django_user_model):
+    return django_user_model.objects.create_user(username='tester', password='secret')

--- a/backend/annotations/conftest.py
+++ b/backend/annotations/conftest.py
@@ -1,6 +1,19 @@
 import pytest
 
+from projects.models import Project
+
 
 @pytest.fixture
 def django_test_user(django_user_model):
     return django_user_model.objects.create_user(username='tester', password='secret')
+
+
+@pytest.fixture()
+def project(db, django_test_user):
+    project = Project.objects.create(
+        name='project',
+        display_name='Project',
+    )
+    project.users.add(django_test_user)
+    project.save()
+    return project

--- a/backend/triplestore/management/commands/import_legacy_data.py
+++ b/backend/triplestore/management/commands/import_legacy_data.py
@@ -103,7 +103,7 @@ def add_collections(collections: dict, project_uri: str, record_mapping: RecordM
         add_records_to_collection(record_iris, collection_iri)
 
 
-def add_annotations(annotations: dict, record_mapping: dict):
+def add_annotations(annotations: dict, project_uri: str, record_mapping: dict):
     for record_uri in annotations:
         try:
             record_iri = record_mapping[record_uri]
@@ -114,10 +114,12 @@ def add_annotations(annotations: dict, record_mapping: dict):
             # We expect a dict with annotation keys as keys and annotation values as values
             assert isinstance(annotation, dict)
             for key in annotation:
-                add_annotation(record_iri, key, annotation[key])
+                add_annotation(record_iri, key, annotation[key], project_uri)
 
 
-def add_annotation(record_iri: str, annotation_key: str, annotation_value: str):
+def add_annotation(
+        record_iri: str, annotation_key: str, annotation_value: str, project: str
+):
     if annotation_key == "EDPOP Glossary":
         try:
             body = URIRef(glossary_mapping[annotation_value.strip()])
@@ -136,6 +138,7 @@ def add_annotation(record_iri: str, annotation_key: str, annotation_value: str):
     graph = Graph(identifier=ANNOTATION_GRAPH_IDENTIFIER)
     triples = [
         (subject_node, RDF.type, EDPOPCOL.Annotation),
+        (subject_node, AS.context, URIRef(project)),
         (subject_node, OA.hasTarget, target_node),
         (target_node, OA.hasSource, URIRef(record_iri)),
         (subject_node, OA.motivatedBy, motivation),
@@ -167,4 +170,4 @@ class Command(BaseCommand):
 
         record_mapping = add_records(records)
         add_collections(collections, project_uri, record_mapping)
-        add_annotations(annotations, record_mapping)
+        add_annotations(annotations, project_uri, record_mapping)

--- a/frontend/vre/annotation/annotation.model.js
+++ b/frontend/vre/annotation/annotation.model.js
@@ -57,15 +57,24 @@ export var Annotation = JsonLdModel.extend({
     // Fields that are normally nested in JSON-LD, but get hoisted to the
     // top-level `attributes` for more convenient access. See the overridden
     // `parse` and `toJSON` methods below.
-    flatFields: ['motivation', 'tagURL', 'oa:hasSource', 'edpopcol:field', 'edpopcol:originalText'],
+    flatFields: [
+        'context',
+        'motivation',
+        'tagURL',
+        'oa:hasSource',
+        'edpopcol:field',
+        'edpopcol:originalText',
+    ],
 
     parse: function(response, options) {
         var anno = parent(Annotation.prototype)
             .parse.call(this, response, options),
             flat = {},
+            context = anno['as:context'],
             motivation = anno['oa:motivatedBy'],
             body = anno['oa:hasBody'],
             target = anno['oa:hasTarget'];
+        if (context) flat.context = context['@id'];
         if (motivation) flat.motivation = motivation['@id'];
         if (body && body['@id']) flat.tagURL = body['@id'];
         if (target) {
@@ -85,6 +94,7 @@ export var Annotation = JsonLdModel.extend({
     toJSON: function(options) {
         var jsonld = parent(Annotation.prototype)
             .toJSON.call(this, options),
+            flatContext = jsonld.context,
             flatMotivation = jsonld.motivation,
             flatTagURL = jsonld.tagURL,
             target = jsonld['oa:hasTarget'] || {},
@@ -100,6 +110,7 @@ export var Annotation = JsonLdModel.extend({
         if (flatSource || flatSelector) jsonld['oa:hasTarget'] = target;
         if (flatTagURL) jsonld['oa:hasBody'] = {'@id': flatTagURL};
         if (flatMotivation) jsonld['oa:motivatedBy'] = {'@id': flatMotivation};
+        if (flatContext) jsonld['as:context'] = {'@id': flatContext};
         _.each(this.flatFields, stripAttribute(jsonld));
         return jsonld;
     },

--- a/frontend/vre/annotation/annotation.model.test.js
+++ b/frontend/vre/annotation/annotation.model.test.js
@@ -5,6 +5,7 @@ import { Annotation } from './annotation.model';
 
 const deepAnnotation = {
     '@id': 'http://example.com/anno',
+    'as:context': {'@id': 'http://example.com/project'},
     'oa:motivatedBy': {'@id': 'oa:commenting'},
     'oa:hasBody': 'awesome',
     'oa:hasTarget': {
@@ -18,6 +19,7 @@ const deepAnnotation = {
 
 const flatAnnotation = {
     '@id': deepAnnotation['@id'],
+    context: deepAnnotation['as:context']['@id'],
     motivation: deepAnnotation['oa:motivatedBy']['@id'],
     'oa:hasBody': deepAnnotation['oa:hasBody'],
     'oa:hasSource': deepAnnotation['oa:hasTarget']['oa:hasSource']['@id'],
@@ -27,6 +29,7 @@ const flatAnnotation = {
 
 const serverMod = {
     '@id': 'http://example.com/anno2',
+    'as:context': deepAnnotation['as:context'],
     'oa:motivatedBy': {'@id': 'oa:tagging'},
     'oa:hasBody': {'@id': 'http://example.com/almanac'},
     'oa:hasTarget': {
@@ -40,6 +43,7 @@ const serverMod = {
 
 const clientMod = {
     '@id': serverMod['@id'],
+    context: serverMod['as:context']['@id'],
     motivation: serverMod['oa:motivatedBy']['@id'],
     tagURL: serverMod['oa:hasBody']['@id'],
     'oa:hasSource': serverMod['oa:hasTarget']['oa:hasSource']['@id'],

--- a/frontend/vre/field/annotatable.view.js
+++ b/frontend/vre/field/annotatable.view.js
@@ -18,7 +18,7 @@ export var AnnotatableView = AggregateView.extend({
     },
 
     edit: function(model) {
-        var project = vreChannel.request('projects:current').get('name'),
+        var project = vreChannel.request('projects:current').id,
             editTarget = model.clone().set('context', project),
             preExisting = this.collection.get(editTarget),
             newRow;

--- a/frontend/vre/field/record.annotations.view.test.js
+++ b/frontend/vre/field/record.annotations.view.test.js
@@ -15,6 +15,7 @@ var currentContext = 'monsters';
 
 var fakeProjectMenu = {
     model: {
+        id: `http://example.com/${currentContext}`,
         get() {
             return currentContext;
         }
@@ -28,12 +29,12 @@ var TestCollection = Collection.extend({
 var annotation = new Annotation({
     "@id": "http://example.org/annotations/1",
     "oa:hasBody": "moss",
-    context: "me, myself and I",
+    context: "http://example.com/me-myself-and-i",
 });
 var annotation2 = new Annotation({
     "@id": "http://example.org/annotations/2",
     "oa:hasBody": "bright",
-    context: "monsters",
+    context: fakeProjectMenu.model.id,
 });
 var testAnnotations = [annotation, annotation2];
 
@@ -169,7 +170,7 @@ describe('RecordAnnotationsView', function() {
             this.fieldView = this.view.items[this.position];
             this.affectedModel = this.fieldView.model;
             assert(this.affectedModel === this.collection.at(this.position));
-            assert(this.affectedModel.get('context') === currentContext);
+            assert(this.affectedModel.get('context') === fakeProjectMenu.model.id);
             this.affectedElement = this.fieldView.$el;
             assert(this.affectedElement.get(0) === this.view.$('tr').get(this.position));
             this.affectedElement.click();


### PR DESCRIPTION
This closes #315. It was easier than I expected.

Frontend and backend cooperate to ensure that each annotation is associated with a project. The backend also enforces that the user must have write access to the project. The `import_legacy_data` script adds a triple to backport the association.

As part of your review, please try re-running the legacy import script on the acceptance server and check that the annotations come out bound to the project. The easiest way to verify this is probably to visit the frontend and alt-click on one of the annotations. That will log three or four views to the console, from innermost to outermost. The innermost model's `.model.attributes` should contain both an `as:context` and a `context` property with the full IRI of the project.