### PR TITLE
Update live

### DIFF
--- a/frontend/vre/collection/add-to-collection.view.js
+++ b/frontend/vre/collection/add-to-collection.view.js
@@ -55,7 +55,7 @@ export var AddToCollectionView = View.extend({
         var selected_collections = this.$('select').val();
         if (!selected_collections.length) return;
         var records_and_collections = new AdditionsToCollections({
-            'records': selected_records,
+            'records': _.map(selected_records, 'id'),
             'collections': selected_collections,
         });
         records_and_collections.save().then(

--- a/frontend/vre/collection/add-to-collection.view.js
+++ b/frontend/vre/collection/add-to-collection.view.js
@@ -58,7 +58,7 @@ export var AddToCollectionView = View.extend({
             'records': _.map(selected_records, 'id'),
             'collections': selected_collections,
         });
-        records_and_collections.save().then(
+        records_and_collections.save(null, {records: selected_records}).then(
             this.showSuccess.bind(this),
             this.showError.bind(this),
         );

--- a/frontend/vre/collection/add-to-collection.view.js
+++ b/frontend/vre/collection/add-to-collection.view.js
@@ -77,7 +77,7 @@ export var AddToCollectionView = View.extend({
     },
     showAlert: function(level, message) {
         var alert = new AlertView({level: level, message: message});
-        alert.render().$el.prependTo(this.el);
+        alert.$el.prependTo(this.el);
         alert.animate('remove');
     },
 });

--- a/frontend/vre/collection/additions-to-collections.js
+++ b/frontend/vre/collection/additions-to-collections.js
@@ -1,5 +1,16 @@
 import Backbone from 'backbone';
 
+import { vreChannel } from '../radio.js';
+
 export var AdditionsToCollections = Backbone.Model.extend({
     url: '/api/add-selection/',
+    save: function(attributes, options) {
+        var promise = AdditionsToCollections.__super__.save
+            .call(this, attributes, options);
+        promise.then(this.broadcast.bind(this, options.records));
+        return promise;
+    },
+    broadcast: function(records) {
+        vreChannel.trigger('collections:added', this, records);
+    },
 });

--- a/frontend/vre/globals/collections.js
+++ b/frontend/vre/globals/collections.js
@@ -1,0 +1,31 @@
+import _ from 'lodash';
+
+import { vreChannel } from '../radio';
+import { VRECollections } from '../collection/collection.model';
+
+// The next two variables are exported, but only for consumption by the main
+// module. Other code units should use the radio interface at the bottom!
+
+// All collections that the user can access.
+export var myCollections = new VRECollections();
+
+// Same but without the one currently selected.
+export var unsalientCollections = new VRECollections();
+
+// We ensure that unsalientCollections stays in sync with myCollections.
+myCollections.on({
+    add: collection => unsalientCollections.add(collection),
+    remove: collection => unsalientCollections.remove(collection),
+});
+
+// Deferred initialization of myCollections.
+function initMine(callback) {
+    VRECollections.mine(myCollections);
+    myCollections.once('sync', callback);
+    return myCollections;
+}
+
+// Injectable interface for unit modules.
+vreChannel.reply('unsalientcollections', _.constant(unsalientCollections));
+vreChannel.reply('allcollections', _.constant(myCollections));
+vreChannel.reply('collections:fetch', initMine);

--- a/frontend/vre/globals/collections.js
+++ b/frontend/vre/globals/collections.js
@@ -25,7 +25,26 @@ function initMine(callback) {
     return myCollections;
 }
 
+// Helper function for the next.
+var getCollection = myCollections.get.bind(myCollections);
+
+// Update cached collections when models have been added.
+// `additions` is an instance of the `AdditionsToCollections` class.
+// `records` is an array of `Record` instances.
+function addRecords(additions, records) {
+    var collectionIDs = additions.get('collections');
+    var collections = _.map(collectionIDs, getCollection);
+    // Get the .records of each collection. Not all collections might have this
+    // property.
+    var maybeRecords = _.map(collections, 'records');
+    // Filter to only obtain the `.records` that were defined.
+    var collectionRecords = _.filter(maybeRecords);
+    // Finally, actually update the cached collections.
+    _.each(collectionRecords, c => c.add(records));
+}
+
 // Injectable interface for unit modules.
 vreChannel.reply('unsalientcollections', _.constant(unsalientCollections));
 vreChannel.reply('allcollections', _.constant(myCollections));
 vreChannel.reply('collections:fetch', initMine);
+vreChannel.on('collections:added', addRecords);

--- a/frontend/vre/globals/variables.js
+++ b/frontend/vre/globals/variables.js
@@ -1,1 +1,0 @@
-export var GlobalVariables = {};

--- a/frontend/vre/main.js
+++ b/frontend/vre/main.js
@@ -9,13 +9,12 @@ window.DEBUGGING = true;
 
 import './record/record.opening.aspect';
 import { vreChannel } from './radio';
-import { VRECollections } from './collection/collection.model';
 import { CatalogSearchView } from './catalog/catalog.search.view';
 import { BrowseCollectionView } from './collection/browse-collection.view';
 import { FilteredCollection } from "./utils/filtered.collection";
 
 import { SelectCollectionView } from './collection/select-collection.view';
-import { GlobalVariables } from './globals/variables';
+import { myCollections, unsalientCollections } from './globals/collections.js';
 import './globals/user';
 import './globals/projects.js';
 import { accountMenu } from './globals/accountMenu';
@@ -25,13 +24,6 @@ import { StateModel } from './utils/state.model.js';
 import { WelcomeView } from './utils/welcome.view.js';
 import {Record} from "./record/record.model";
 
-// Dangerously global variable (accessible from dependency modules).
-GlobalVariables.myCollections = new VRECollections();
-
-// Regular global variables, only visible in this module.
-
-// All collections except for the one currently selected.
-var unsalientCollections = new VRECollections();
 var catalogs = new Catalogs([], {comparator: 'name'});
 var visibleCatalogs = new FilteredCollection(catalogs, (catalog) => {
     // Do not show the blank records catalogue
@@ -41,7 +33,7 @@ var catalogDropdown = new SelectCatalogView({
     collection: visibleCatalogs
 });
 var collectionDropdown = new SelectCollectionView({
-    collection: GlobalVariables.myCollections
+    collection: myCollections
 });
 var navigationState = new StateModel;
 
@@ -64,7 +56,7 @@ var router = new VRERouter();
 router.on({
     'route:showCollection': id => navigationState.set({
         browsingType: 'collection',
-        browsingContext: GlobalVariables.myCollections.find({name: id})
+        browsingContext: myCollections.find({name: id})
     }),
     'route:showCatalog': id => navigationState.set({
         browsingType: 'catalog',
@@ -113,18 +105,10 @@ function showRecord(id) {
     });
 }
 
-GlobalVariables.myCollections.on({
+myCollections.on({
     focus: showCollection,
     blur: hideCollection,
 });
-
-// We ensure that unsalientCollections stays in sync with myCollections and that
-// it is available via the radio.
-GlobalVariables.myCollections.on({
-    add: collection => unsalientCollections.add(collection),
-    remove: collection => unsalientCollections.remove(collection),
-});
-vreChannel.reply('unsalientcollections', _.constant(unsalientCollections));
 
 // Make current browsing type and context available to all views via the radio.
 vreChannel.reply('browsingType', () => navigationState.get('browsingType'));
@@ -138,10 +122,9 @@ vreChannel.reply('getCatalog', (uri) => catalogs.get(uri));
 // 2. the CSRF cookie has been obtained.
 function prepareCollections() {
     $('#result-detail').modal({show: false});
-    VRECollections.mine(GlobalVariables.myCollections);
     catalogs.fetch();
     vreChannel.request('projects:fetch', finish);
-    GlobalVariables.myCollections.once('sync', finish);
+    vreChannel.request('collections:fetch', finish);
     catalogs.once('sync', finish);
 
     // Add account menu
@@ -151,7 +134,7 @@ function prepareCollections() {
 }
 
 // We want this code to run after prepareCollections has run and both
-// GlobalVariables.myCollections and all projects have fully loaded.
+// myCollections and all projects have fully loaded.
 function startRouting() {
     $('#navbar-left').append(
         catalogDropdown.el,

--- a/frontend/vre/record/record.detail.view.js
+++ b/frontend/vre/record/record.detail.view.js
@@ -109,7 +109,7 @@ export var RecordDetailView = CompositeView.extend({
     },
 
     submitToCollections: function() {
-        this.addSelect.submitForm([this.model.id]);
+        this.addSelect.submitForm([this.model]);
     },
 
     removeFromCollection: function() {

--- a/frontend/vre/record/record.detail.view.js
+++ b/frontend/vre/record/record.detail.view.js
@@ -8,7 +8,6 @@ import { Field, FlatterFields } from '../field/field.model';
 import { AddToCollectionView } from '../collection/add-to-collection.view';
 import { RemoveFromCollectionView } from '../collection/remove-from-collection.view.js';
 import { typeTranslation } from '../utils/generic-functions.js';
-import { GlobalVariables } from '../globals/variables';
 import recordDetailTemplate from './record.detail.view.mustache';
 import typeIconTemplate from './record.type.icon.mustache';
 import {DigitizationsView} from "../digitization/digitizations.view";
@@ -82,11 +81,12 @@ export var RecordDetailView = CompositeView.extend({
             collection: recordAnnotations,
         }).render();
         this.annotationsView.listenTo(this.fieldsView, 'edit', this.annotationsView.edit);
+        var myCollections = vreChannel.request('allcollections');
         this.addSelect = new AddToCollectionView({
-            collection: GlobalVariables.myCollections,
+            collection: myCollections,
         }).on('addRecords', this.submitToCollections, this);
         this.removeButton = new RemoveFromCollectionView({
-            collection: GlobalVariables.myCollections,
+            collection: myCollections,
         }).on('removeRecords', this.removeFromCollection, this);
         this.render();
     },

--- a/frontend/vre/record/record.list.managing.view.js
+++ b/frontend/vre/record/record.list.managing.view.js
@@ -72,7 +72,7 @@ export var RecordListManagingView = CompositeView.extend({
     removeFromCollection: function() {
         var selection = this.recordListView.currentSelection();
         this.removeButton.submitForm({
-            records: selection,
+            records: _.map(selection, 'id'),
             collection: this.model.get('uri'),
         }).then(this.purgeRemoved.bind(this, selection));
     },

--- a/frontend/vre/record/record.list.managing.view.js
+++ b/frontend/vre/record/record.list.managing.view.js
@@ -1,7 +1,6 @@
 import { CompositeView } from '../core/view.js';
 import { AddToCollectionView } from '../collection/add-to-collection.view';
 import { RemoveFromCollectionView } from '../collection/remove-from-collection.view.js';
-import { GlobalVariables } from '../globals/variables';
 import recordListManagingTemplate from './record.list.managing.view.mustache';
 import {RecordListView} from "./record.list.view";
 import {vreChannel} from "../radio";
@@ -42,7 +41,7 @@ export var RecordListManagingView = CompositeView.extend({
         this.vreCollectionsSelect = new AddToCollectionView()
             .render().on('addRecords', this.submitToCollections, this);
         this.removeButton = new RemoveFromCollectionView({
-            collection: GlobalVariables.myCollections,
+            collection: vreChannel.request('allcollections'),
         }).on('removeRecords', this.removeFromCollection, this);
         this.recordListView = new RecordListView({
             collection: this.collection,

--- a/frontend/vre/record/record.list.view.js
+++ b/frontend/vre/record/record.list.view.js
@@ -6,10 +6,6 @@ import {vreChannel} from "../radio";
 import {adjustDefinitions} from "../utils/tabulator-utils";
 import {BIBLIOGRAPHICAL, BIOGRAPHICAL} from "../utils/record-ontology";
 
-function getModelId(rowData) {
-    return rowData.model.id;
-}
-
 function getDefaultSort(recordClass, type) {
     if (type === "catalog") {
         /* Do not sort catalog results by default, because the API's original
@@ -110,7 +106,7 @@ export var RecordListView = Backbone.View.extend({
     },
 
     currentSelection: function() {
-        return _.map(this.table.getSelectedData(), getModelId);
+        return _.map(this.table.getSelectedData(), 'model');
     },
 
     downloadXLSX: function() {


### PR DESCRIPTION
This fixes the long-standing but late-documented issue where added records would not be visible in previously cached collections (#309).

I employed "spooky action at a distance" through the radio channel. Since I was at it, I also eliminated the last usage of `GlobalVariables`.

After merging this, I think we can also close the following issues. I am not 100% sure all instances of those issues have been cleared up, but I am quite sure that they are now so rare that they don't warrant open issues anymore. We can still refer to the tickets in commit messages after closing them.

Close #123, close #130, close #131.

As part of your review, I invite you to try it out locally.