### PR TITLE
Record ordering fixes

### DIFF
--- a/frontend/vre/css/style.css
+++ b/frontend/vre/css/style.css
@@ -71,6 +71,15 @@ form.form-inline.inline-editor {
     z-index: 1060;
 }
 
+.highlighted {
+    font-weight: bold;
+}
+
+.tabulator-row {
+    transition-property: font-weight;
+    transition-duration: 0.15s;
+}
+
 @media (prefers-color-scheme: dark) {
     html {
         filter: invert(1) hue-rotate(180deg) contrast(0.9) brightness(0.9);

--- a/frontend/vre/record/record.detail.view.js
+++ b/frontend/vre/record/record.detail.view.js
@@ -58,9 +58,8 @@ export var RecordDetailView = CompositeView.extend({
         var model = this.model;
         model.getAnnotations();
         if (model.collection) {
-            var index = model.collection.indexOf(model);
-            this.isFirst = (index === 0);
-            this.isLast = (index === model.collection.length - 1);
+            this.previousRecord = vreChannel.request('getPreviousRecord', this.model);
+            this.nextRecord = vreChannel.request('getNextRecord', this.model);
         }
         var fields = new FlatterFields(null, {record: model});
         var digitizations = new FilteredCollection(fields, {
@@ -93,8 +92,8 @@ export var RecordDetailView = CompositeView.extend({
 
     renderContainer: function() {
         this.$el.html(this.template(_.assign({
-            first: this.isFirst,
-            last: this.isLast,
+            first: !this.previousRecord,
+            last: !this.nextRecord,
             title: this.model.getMainDisplay(),
             uri: this.model.id,
             inContext: this.model.collection ? true : false,
@@ -131,12 +130,12 @@ export var RecordDetailView = CompositeView.extend({
 
     next: function(event) {
         event && event.preventDefault();
-        vreChannel.trigger('displayNextRecord');
+        if (this.nextRecord) vreChannel.trigger('displayRecord', this.nextRecord);
     },
 
     previous: function(event) {
         event.preventDefault();
-        vreChannel.trigger('displayPreviousRecord');
+        if (this.previousRecord) vreChannel.trigger('displayRecord', this.previousRecord);
     },
 
     reload: function(event) {

--- a/frontend/vre/record/record.detail.view.js
+++ b/frontend/vre/record/record.detail.view.js
@@ -52,6 +52,7 @@ export var RecordDetailView = CompositeView.extend({
         'click #load_next': 'next',
         'click #load_previous': 'previous',
         'click #reload': 'reload',
+        'hidden.bs.modal': 'triggerRemove',
     },
 
     initialize: function(options) {
@@ -104,6 +105,10 @@ export var RecordDetailView = CompositeView.extend({
     remove: function() {
         this.$el.modal('hide');
         RecordDetailView.__super__.remove.call(this);
+        return this.trigger('remove');
+    },
+
+    triggerRemove: function() {
         return this.trigger('remove');
     },
 

--- a/frontend/vre/record/record.list.view.js
+++ b/frontend/vre/record/record.list.view.js
@@ -51,6 +51,7 @@ export var RecordListView = Backbone.View.extend({
      * @type {?string}
      */
     recordClass: null,
+    highlightedRow: null,
 
     initialize: function(options) {
         _.assign(this, _.pick(options, ['recordClass', 'type']));
@@ -90,6 +91,14 @@ export var RecordListView = Backbone.View.extend({
                     cell.getRow().toggleSelect();
                 },
             },
+            rowFormatter: function(row) {
+                var data = row.getData();
+                if (data.highlighted === true) {
+                    row.getElement().classList.add("highlighted");
+                } else {
+                    row.getElement().classList.remove("highlighted");
+                }
+            },
             headerFilterLiveFilterDelay: 0,
         });
         this.table.on("cellClick", (e, cell) => {
@@ -104,6 +113,8 @@ export var RecordListView = Backbone.View.extend({
             const model = cell.getRow().getData().model;
             vreChannel.trigger('displayRecord', model);
         });
+        vreChannel.on('highlightRecord', this.highlightRecord.bind(this));
+        vreChannel.on('unhighlightRecord', this.unhighlightRecord.bind(this));
         vreChannel.reply('getNextRecord', this.getNextRecord.bind(this));
         vreChannel.reply('getPreviousRecord', this.getPreviousRecord.bind(this));
         return this;
@@ -131,6 +142,22 @@ export var RecordListView = Backbone.View.extend({
         return this;
     },
 
+    highlightRecord: function(recordModel) {
+        this.unhighlightRecord();
+        var toHighlight = this.table.getRow(recordModel.id);
+        toHighlight.scrollTo("center", false);
+        toHighlight.getData().highlighted = true;
+        toHighlight.reformat();
+        this.highlightedRow = toHighlight;
+    },
+
+    unhighlightRecord: function() {
+        if (this.highlightedRow) {
+            this.highlightedRow.getData().highlighted = false;
+            this.highlightedRow.reformat();
+        }
+    },
+
     getNextRecord: function(recordModel) {
         var currentRow = this.table.getRow(recordModel.id);
         var nextRow = currentRow.getNextRow();
@@ -148,6 +175,8 @@ export var RecordListView = Backbone.View.extend({
     },
 
     remove: function() {
+        vreChannel.off('highlightRecord');
+        vreChannel.off('unhighlightRecord');
         vreChannel.off('getNextRecord');
         vreChannel.off('getPreviousRecord');
         this.removeTable();

--- a/frontend/vre/record/record.list.view.js
+++ b/frontend/vre/record/record.list.view.js
@@ -10,6 +10,12 @@ function getModelId(rowData) {
     return rowData.model.id;
 }
 
+/**
+ *
+ * @param recordClass
+ * @param type
+ * @returns {[{column: string, dir: string}]|null}
+ */
 function getDefaultSort(recordClass, type) {
     if (type === "catalog") {
         /* Do not sort catalog results by default, because the API's original
@@ -47,7 +53,7 @@ export var RecordListView = Backbone.View.extend({
     recordClass: null,
 
     initialize: function(options) {
-        _.assign(this, _.pick(options, ['recordClass']));
+        _.assign(this, _.pick(options, ['recordClass', 'type']));
         this.render().listenTo(this.collection, 'update', this.render);
     },
 
@@ -66,7 +72,7 @@ export var RecordListView = Backbone.View.extend({
             autoColumns: true,
             autoColumnsDefinitions: (autodetected) => {return adjustDefinitions(autodetected, this.recordClass)},
             layout: "fitColumns",
-            initialSort: getDefaultSort(this.recordClass),
+            initialSort: getDefaultSort(this.recordClass, this.type),
             resizableColumnFit: true,
             movableColumns: true,
             clipboard: "copy",

--- a/frontend/vre/record/record.list.view.js
+++ b/frontend/vre/record/record.list.view.js
@@ -104,6 +104,8 @@ export var RecordListView = Backbone.View.extend({
             const model = cell.getRow().getData().model;
             vreChannel.trigger('displayRecord', model);
         });
+        vreChannel.reply('getNextRecord', this.getNextRecord.bind(this));
+        vreChannel.reply('getPreviousRecord', this.getPreviousRecord.bind(this));
         return this;
     },
 
@@ -127,5 +129,28 @@ export var RecordListView = Backbone.View.extend({
     downloadCSV: function() {
         this.table.download("csv", "edpop.csv");
         return this;
+    },
+
+    getNextRecord: function(recordModel) {
+        var currentRow = this.table.getRow(recordModel.id);
+        var nextRow = currentRow.getNextRow();
+        if (nextRow) {
+            return nextRow.getData().model;
+        }
+    },
+
+    getPreviousRecord: function(recordModel) {
+        var currentRow = this.table.getRow(recordModel.id);
+        var previousRow = currentRow.getPrevRow();
+        if (previousRow) {
+            return previousRow.getData().model;
+        }
+    },
+
+    remove: function() {
+        vreChannel.off('getNextRecord');
+        vreChannel.off('getPreviousRecord');
+        this.removeTable();
+        Backbone.View.prototype.remove.call(this);
     },
 });

--- a/frontend/vre/record/record.model.js
+++ b/frontend/vre/record/record.model.js
@@ -39,6 +39,7 @@ export var Record = JsonLdModel.extend({
         const data = {
             model: this,
             type: this.get('@type'),
+            id: this.id,  // id is used for identification by Tabular by default
         };
         fields.forEach((field) => {
             data[field.id] = field.getMainDisplay();

--- a/frontend/vre/record/record.opening.aspect.js
+++ b/frontend/vre/record/record.opening.aspect.js
@@ -16,19 +16,6 @@ function displayRecord(model) {
     currentModal.display();
 }
 
-function shift(direction) {
-    return function() {
-        if (!currentModal) return;
-        var model = currentModal.model;
-        var collection = model.collection;
-        var oldIndex = collection.indexOf(model);
-        var newIndex = oldIndex + direction;
-        displayRecord(collection.at(newIndex));
-    }
-}
-
 vreChannel.on({
     displayRecord: displayRecord,
-    displayNextRecord: shift(+1),
-    displayPreviousRecord: shift(-1),
 });

--- a/frontend/vre/record/record.opening.aspect.js
+++ b/frontend/vre/record/record.opening.aspect.js
@@ -5,6 +5,7 @@ var currentModal = null;
 
 function purgeModal() {
     currentModal = null;
+    vreChannel.trigger('unhighlightRecord');
 }
 
 function displayRecord(model) {
@@ -14,6 +15,7 @@ function displayRecord(model) {
         .on('remove', purgeModal);
     }
     currentModal.display();
+    vreChannel.trigger('highlightRecord', model);
 }
 
 vreChannel.on({

--- a/frontend/vre/utils/tabulator-utils.js
+++ b/frontend/vre/utils/tabulator-utils.js
@@ -69,6 +69,19 @@ export const columnChooseMenu = function(){
         });
     }
 
+    menu.push({
+        separator: true
+    }, {
+        label: "Restore ordering",
+        action: function (e) {
+            if (this.options.initialSort) {
+                this.setSort(this.options.initialSort);
+            } else {
+                this.clearSort();
+            }
+        }.bind(this)
+    });
+
     return menu;
 };
 


### PR DESCRIPTION
This PR fixes some problems related to the ordering of records:

* Close #312: follow the record order according to the table when going back and forth in the modal
* Close #338: keep the original order of catalogue records by default (this was already supposed to work, but due to a bug it didn't)
* Add an item to the context menu that lets you restore the order of the table
* As a bonus, this PR adds highlighting of the currently selected record