### PR TITLE
Filter annotations based on currently selected project

### DIFF
--- a/backend/annotations/api.py
+++ b/backend/annotations/api.py
@@ -237,7 +237,7 @@ class AnnotationEditView(RDFView):
 
 class AnnotationsPerTargetView(RDFView):
     '''
-    View the records inside a collection
+    View the annotations associated with a record within a particular project.
     '''
 
     renderer_classes = (JsonLdRenderer, TurtleRenderer)

--- a/backend/annotations/api.py
+++ b/backend/annotations/api.py
@@ -48,7 +48,8 @@ construct {
 where {
   graph ?annotations {
     ?a ?pa ?oa ;
-       oa:hasTarget ?t .
+       oa:hasTarget ?t ;
+       as:context ?project .
     ?t ?pt ?ot ;
        oa:hasSource ?record .
     optional {
@@ -244,9 +245,11 @@ class AnnotationsPerTargetView(RDFView):
 
     def get_graph(self, request: Request, record: str, **kwargs) -> Graph:
         record_uri = URIRef(record)
+        project_uri = URIRef(request.GET['project'])
         store = settings.RDFLIB_STORE
         query = record_annotations_query
         return graph_from_triples(store.query(query, initBindings={
             'annotations': ANNOTATION_GRAPH_IDENTIFIER,
             'record': record_uri,
+            'project': project_uri,
         }, initNs=NS))

--- a/backend/annotations/api_test.py
+++ b/backend/annotations/api_test.py
@@ -16,7 +16,7 @@ def create_annotation(client, target, body, django_test_user, project) -> str:
         "@context": JSON_LD_CONTEXT,
         "oa:hasTarget": target,
         "oa:hasBody": body,
-        "as:context": project.uri,
+        "as:context": {'@id': project.uri},
     }
     client.force_login(django_test_user)
     response = client.post('/api/annotation/', data, content_type='application/ld+json')
@@ -56,7 +56,8 @@ def test_list_annotations(client, triplestore, django_test_user, project):
                             django_test_user, project)
     uri2 = create_annotation(client, target, 'This is another annotation',
                              django_test_user, project)
-    response = client.get(f'/api/record-annotations/{quote_plus(source)}/')
+    endpoint = f'/api/record-annotations/{quote_plus(source)}/?project={quote_plus(project.uri)}'
+    response = client.get(endpoint)
     assert response.status_code == 200
     graph = response.data
     assert len(list(graph.triples((None, OA.hasSource, URIRef(source))))) == 2

--- a/frontend/vre/annotation/annotation.model.js
+++ b/frontend/vre/annotation/annotation.model.js
@@ -4,6 +4,7 @@ import { parent } from '@uu-cdh/backbone-collection-transformers/src/inheritance
 import {getDateTimeLiteral, JsonLdModel, JsonLdNestedCollection} from '../utils/jsonld.model';
 import {UserLd} from '../user/user.ld.model';
 import {glossary} from '../utils/glossary';
+import { vreChannel } from '../radio.js';
 
 // Helper function for removing multiple properties from an object in iteration.
 function stripAttribute(container) {
@@ -135,11 +136,17 @@ export var Annotations = JsonLdNestedCollection.extend({
 
     initialize: function(model, options) {
         _.assign(this, _.pick(options, ['target']));
-        this.url = `/api/record-annotations/${encodeURIComponent(this.target)}/`;
         this.on('remove', this.deleteAnnotation);
     },
 
     deleteAnnotation: function(annotation) {
         annotation.destroy();
+    },
+
+    url: function() {
+        var targetPart = encodeURIComponent(this.target);
+        var projectId = vreChannel.request('projects:current').id;
+        var projectPart = encodeURIComponent(projectId);
+        return `/api/record-annotations/${targetPart}/?project=${projectPart}`;
     },
 });

--- a/frontend/vre/annotation/annotation.model.test.js
+++ b/frontend/vre/annotation/annotation.model.test.js
@@ -1,7 +1,8 @@
 import assert from 'assert';
 import sinon from 'sinon';
 
-import { Annotation } from './annotation.model';
+import { Annotation, Annotations } from './annotation.model';
+import { vreChannel } from '../radio.js';
 
 const deepAnnotation = {
     '@id': 'http://example.com/anno',
@@ -95,5 +96,37 @@ describe('Annotation model', () => {
         // finally, toJSON tells us what will be sent to the server
         const serialized = model.toJSON();
         assert.deepStrictEqual(serialized, serverMod);
+    });
+});
+
+describe('Annotations collection', () => {
+    const target = 'http://example.com/target',
+          project = {id: 'http://example.com/project'};
+    let collection;
+
+    beforeEach(() => {
+        collection = new Annotations(null, {target});
+        vreChannel.reply('projects:current', _.constant(project));
+    });
+
+    afterEach(() => {
+        vreChannel.stopReplying('projects:current');
+        collection.off().stopListening().reset();
+    });
+
+    describe('url method', () => {
+        it('addresses the record-annotations endpoint', () => {
+            assert(collection.url().startsWith('/api/record-annotations/'))
+        });
+
+        it('includes the escaped URI of the target record', () => {
+            const targetPart = `/${encodeURIComponent(target)}/`;
+            assert(collection.url().includes(targetPart));
+        });
+
+        it('ends with the current project', () => {
+            const projectPart = `/?project=${encodeURIComponent(project.id)}`;
+            assert(collection.url().endsWith(projectPart));
+        });
     });
 });

--- a/frontend/vre/field/record.annotations.view.test.js
+++ b/frontend/vre/field/record.annotations.view.test.js
@@ -121,6 +121,7 @@ function newAnnotationTrashed() {
 
 describe('RecordAnnotationsView', function() {
     before(function() {
+        this.xhr = sinon.useFakeXMLHttpRequest();
         vreChannel.reply('projects:current', () => fakeProjectMenu.model);
     });
 
@@ -142,6 +143,7 @@ describe('RecordAnnotationsView', function() {
 
     after(function() {
         vreChannel.stopReplying('projects:current');
+        this.xhr.restore();
     });
 
     it('has a button for adding new fields', function() {


### PR DESCRIPTION
I started this branch a month ago, but I got stuck on a failing test right after I started and that was just before the Christmas holidays. Fortunately, a break does wonders to get unstuck.

I modified the `/api/record-annotations/` endpoint to accept and expect a new `?project=<URIEncoded project URI>` query parameter (#317). Initially, I wanted to go with a path component, just like with the record URI that is already passed to this endpoint, but Django's router won't parse this correctly. It seems that Django's middleware *first* unencodes URI components and *then* parses the endpoint, causing even escaped slashes to be processed.

I then modified the `Annotations` collection class in the frontend to use the new query parameter (#316). As I was testing this, I discovered a problem with another frontend test that I fixed in the last commit of this branch.

The tests pass and the application correctly filters annotations based on the currently selected project. Due to #319 not being implemented yet, this can lead to confusing behavior in local development: if you select one project, open a collection, open a record, make an annotation, close the record, select another project and open the same record again, you will still see your annotation. You can make the cached annotation disappear by refreshing the page. If you then switch back to the first project and open the record again, your annotation will not appear, until you refresh the page again. Fortunately, this should not be an issue in production because there is only one project at this time. I expect the bug to disappear when we implement #319.