### PR TITLE
Add tag (glossary item) to table view

### DIFF
--- a/frontend/vre/record/record.list.view.js
+++ b/frontend/vre/record/record.list.view.js
@@ -66,7 +66,7 @@ export var RecordListView = Backbone.View.extend({
             height: "calc(100vh - 360px)", // set height to table approximately to what is left of viewport height
             data: initialData,
             autoColumns: true,
-            autoColumnsDefinitions: (autodetected) => {return adjustDefinitions(autodetected, this.recordClass)},
+            autoColumnsDefinitions: (autodetected) => {return adjustDefinitions(autodetected, this.recordClass, this.type)},
             layout: "fitColumns",
             initialSort: getDefaultSort(this.recordClass, this.type),
             resizableColumnFit: true,

--- a/frontend/vre/record/record.list.view.js
+++ b/frontend/vre/record/record.list.view.js
@@ -57,6 +57,7 @@ export var RecordListView = Backbone.View.extend({
         const data = this.collection.toTabularData();
         if (this.table === null) return this.createTable(data);
         this.table.replaceData(data);
+        this.connectToData();
         return this;
     },
 
@@ -107,11 +108,24 @@ export var RecordListView = Backbone.View.extend({
             const model = cell.getRow().getData().model;
             vreChannel.trigger('displayRecord', model);
         });
+        this.table.on("tableBuilt", this.connectToData.bind(this));
         vreChannel.on('highlightRecord', this.highlightRecord.bind(this));
         vreChannel.on('unhighlightRecord', this.unhighlightRecord.bind(this));
         vreChannel.reply('getNextRecord', this.getNextRecord.bind(this));
         vreChannel.reply('getPreviousRecord', this.getPreviousRecord.bind(this));
         return this;
+    },
+
+    connectToData: function() {
+        var rows = this.table.getRows();
+        for (let row of rows) {
+            var record = row.getData().model;
+            record.on("annotations:loaded", function(model) {
+                var tabularData = model.toTabularData();
+                this.table.updateData([tabularData]);
+            }.bind(this));
+            record.getAnnotations();
+        }
     },
 
     removeTable: function() {

--- a/frontend/vre/record/record.list.view.js
+++ b/frontend/vre/record/record.list.view.js
@@ -49,15 +49,17 @@ export var RecordListView = Backbone.View.extend({
 
     initialize: function(options) {
         _.assign(this, _.pick(options, ['recordClass', 'type']));
+        this.listenTo(this.collection, 'annotations:loaded', this.insertRowAnnotations);
         this.render().listenTo(this.collection, 'update', this.render);
     },
 
     render: function() {
         if (this.collection.length === 0) return this.removeTable();
         const data = this.collection.toTabularData();
+        _.invokeMap(this.collection.models, 'getAnnotations');
         if (this.table === null) return this.createTable(data);
         this.table.replaceData(data);
-        this.connectToData();
+        // TODO: replace by _.invoke when switching to Underscore
         return this;
     },
 
@@ -108,7 +110,6 @@ export var RecordListView = Backbone.View.extend({
             const model = cell.getRow().getData().model;
             vreChannel.trigger('displayRecord', model);
         });
-        this.table.on("tableBuilt", this.connectToData.bind(this));
         vreChannel.on('highlightRecord', this.highlightRecord.bind(this));
         vreChannel.on('unhighlightRecord', this.unhighlightRecord.bind(this));
         vreChannel.reply('getNextRecord', this.getNextRecord.bind(this));
@@ -116,16 +117,9 @@ export var RecordListView = Backbone.View.extend({
         return this;
     },
 
-    connectToData: function() {
-        var rows = this.table.getRows();
-        for (let row of rows) {
-            var record = row.getData().model;
-            record.on("annotations:loaded", function(model) {
-                var tabularData = model.toTabularData();
-                this.table.updateData([tabularData]);
-            }.bind(this));
-            record.getAnnotations();
-        }
+    insertRowAnnotations: function(model) {
+        var tabularData = model.toTabularData();
+        this.table.updateData([tabularData]);
     },
 
     removeTable: function() {

--- a/frontend/vre/record/record.model.js
+++ b/frontend/vre/record/record.model.js
@@ -15,12 +15,12 @@ function get_fetch_url(record_uri) {
 
 function getRecordTags(annotations) {
     if (!annotations) return undefined;
-    var recordAnnotations = FilteredCollection(annotations, (annotation) => {
-        return !annotation.get('edpopcol:field') && annotation.get('motivation') === 'oa:tagging';
-    });
-    return recordAnnotations.map((annotation) => {
-        return annotation.getDisplayText();
-    }).join(", ");
+    return annotations.chain()
+    .filter((anno) => !anno.get('edpopcol:field') && anno.get('motivation') === 'oa:tagging')
+    // TODO: replace by _.invoke when switching to Underscore
+    .invokeMap('getDisplayText')
+    .join(', ')
+    .value();
 }
 
 export var Record = JsonLdModel.extend({

--- a/frontend/vre/record/record.model.js
+++ b/frontend/vre/record/record.model.js
@@ -2,6 +2,7 @@ import { Annotations } from '../annotation/annotation.model';
 import { JsonLdModel, JsonLdNestedCollection} from "../utils/jsonld.model";
 import { FlatFields } from "../field/field.model";
 import {vreChannel} from "../radio";
+import { FilteredCollection } from "../utils/filtered.collection";
 
 /**
  * Get the URL to fetch the record on its own from the backend.
@@ -10,6 +11,16 @@ import {vreChannel} from "../radio";
  */
 function get_fetch_url(record_uri) {
     return record_uri.replace('https://edpop.hum.uu.nl/', '/');
+}
+
+function getRecordTags(annotations) {
+    if (!annotations) return undefined;
+    var recordAnnotations = FilteredCollection(annotations, (annotation) => {
+        return !annotation.get('edpopcol:field') && annotation.get('motivation') === 'oa:tagging';
+    });
+    return recordAnnotations.map((annotation) => {
+        return annotation.getDisplayText();
+    }).join(", ");
 }
 
 export var Record = JsonLdModel.extend({
@@ -39,6 +50,9 @@ export var Record = JsonLdModel.extend({
         const data = {
             model: this,
             type: this.get('@type'),
+            fromCatalog: this.getCatalogName(),
+            hasAnnotations: this.annotations && !!this.annotations.length,
+            tags: getRecordTags(this.annotations),
             id: this.id,  // id is used for identification by Tabular by default
         };
         fields.forEach((field) => {
@@ -52,6 +66,7 @@ export var Record = JsonLdModel.extend({
             if (!this.isNew()) {
                 this.annotations.fetch();
             }
+            this.annotations.on('sync', () => this.trigger('annotations:loaded', this));
         }
         return this.annotations;
     },

--- a/frontend/vre/utils/tabulator-utils.js
+++ b/frontend/vre/utils/tabulator-utils.js
@@ -172,6 +172,13 @@ const standardColumns = _.mapValues({
     );
 });
 
+/**
+ * To be used as the `valuesLookup` parameter of the `headerFilterParams`
+ * option of a Tabulator column definition. The return value is an array
+ * of filter options. The options we want to show are all unique values
+ * of the column, with support for cells that contain multiple values
+ * separated by a comma.
+ */
 function getUniqueValues(cell) {
     var cells = cell.getColumn().getCells();
     var data = _.map(cells, c => c.getValue() && c.getValue().split(', '));

--- a/frontend/vre/utils/tabulator-utils.js
+++ b/frontend/vre/utils/tabulator-utils.js
@@ -182,7 +182,8 @@ const standardColumns = _.mapValues({
 function getUniqueValues(cell) {
     var cells = cell.getColumn().getCells();
     var data = _.map(cells, c => c.getValue() && c.getValue().split(', '));
-    data = _.chain(data).flatten().filter(_.negate(_.isEmpty)).uniq().sortBy().value();
+    // TODO: replace sortedUniq() by uniq(true) when switching to Underscore
+    data = _.chain(data).flatten().filter(_.negate(_.isEmpty)).sort().sortedUniq().value();
     data.unshift({
         label: '(all)',
         value: '',

--- a/frontend/vre/utils/tabulator-utils.js
+++ b/frontend/vre/utils/tabulator-utils.js
@@ -171,6 +171,24 @@ const standardColumns = _.mapValues({
     );
 });
 
+function getUniqueValues(cell) {
+    var cells = cell.getColumn().getCells();
+    var data = _.map(cells, c => c.getValue() && c.getValue().split(', '));
+    data = _.flatten(data);
+    _.remove(data, _.isEmpty);
+    data = _.uniq(data);
+    data = _.sortBy(data);
+    data.unshift({
+        label: '(all)',
+        value: '',
+    })
+    return data;
+}
+
+/**
+ * Get additional column definitions based on the type of record list (catalog or collection).
+ * @param {string} type - the kind of record list: "catalog" or "collection"
+ */
 function getAdditionalColumns(type) {
     return [{
         field: 'hasAnnotations',
@@ -189,6 +207,10 @@ function getAdditionalColumns(type) {
     }, {
         field: 'tags',
         title: 'Glossary',
+        headerFilter: 'list',
+        headerFilterParams: {
+            valuesLookup: getUniqueValues,
+        },
         visible: type === 'collection',
         headerContextMenu: columnChooseMenu,
     }, {

--- a/frontend/vre/utils/tabulator-utils.js
+++ b/frontend/vre/utils/tabulator-utils.js
@@ -44,7 +44,8 @@ export const columnChooseMenu = function(){
         let label = document.createElement("span");
         let title = document.createElement("span");
 
-        title.textContent = " " + (definition.titleInMenu || definition.title);
+        // For textContent, prefer the headerTooltip, which is the text representation in case the field
+        title.textContent = " " + (definition.headerTooltip || definition.title);
 
         label.appendChild(icon);
         label.appendChild(title);
@@ -193,7 +194,6 @@ function getAdditionalColumns(type) {
     return [{
         field: 'hasAnnotations',
         title: "<i class='fa-regular fa-comment'></i>",
-        titleInMenu: "Has annotations",
         headerTooltip: "Has annotations",
         visible: type === 'collection',
         formatter: 'tickCross',

--- a/frontend/vre/utils/tabulator-utils.js
+++ b/frontend/vre/utils/tabulator-utils.js
@@ -182,10 +182,7 @@ const standardColumns = _.mapValues({
 function getUniqueValues(cell) {
     var cells = cell.getColumn().getCells();
     var data = _.map(cells, c => c.getValue() && c.getValue().split(', '));
-    data = _.flatten(data);
-    _.remove(data, _.isEmpty);
-    data = _.uniq(data);
-    data = _.sortBy(data);
+    data = _.chain(data).flatten().filter(_.negate(_.isEmpty)).uniq().sortBy().value();
     data.unshift({
         label: '(all)',
         value: '',

--- a/frontend/vre/utils/tabulator-utils.js
+++ b/frontend/vre/utils/tabulator-utils.js
@@ -44,7 +44,9 @@ export const columnChooseMenu = function(){
         let label = document.createElement("span");
         let title = document.createElement("span");
 
-        // For textContent, prefer the headerTooltip, which is the text representation in case the field
+        /* For textContent, prefer the headerTooltip, which is the text representation
+           in case the column header consists of an icon
+         */
         title.textContent = " " + (definition.headerTooltip || definition.title);
 
         label.appendChild(icon);

--- a/frontend/vre/utils/tabulator-utils.js
+++ b/frontend/vre/utils/tabulator-utils.js
@@ -44,7 +44,7 @@ export const columnChooseMenu = function(){
         let label = document.createElement("span");
         let title = document.createElement("span");
 
-        title.textContent = " " + definition.title;
+        title.textContent = " " + (definition.titleInMenu || definition.title);
 
         label.appendChild(icon);
         label.appendChild(title);
@@ -171,6 +171,35 @@ const standardColumns = _.mapValues({
     );
 });
 
+function getAdditionalColumns(type) {
+    return [{
+        field: 'hasAnnotations',
+        title: "<i class='fa-regular fa-comment'></i>",
+        titleInMenu: "Has annotations",
+        headerTooltip: "Has annotations",
+        visible: type === 'collection',
+        formatter: 'tickCross',
+        formatterParams: {
+            tickElement: "<i class='fa-regular fa-comment'></i>",
+            crossElement: "",
+        },
+        width: 54,
+        tooltip: (e, cell) => cell.getValue() ? "Record has annotations" : "No annotations",
+        headerContextMenu: columnChooseMenu,
+    }, {
+        field: 'tags',
+        title: 'Glossary',
+        visible: type === 'collection',
+        headerContextMenu: columnChooseMenu,
+    }, {
+        field: 'fromCatalog',
+        title: 'From catalog',
+        visible: type === 'collection',
+        headerContextMenu: columnChooseMenu,
+        tooltip: (e, cell) => cell.getValue(),
+    }];
+}
+
 /**
  * Callback for Tabulator's `autoColumnsDefinitions`. It always returns all
  * columns defined in {@link standardColumns}, but leverages the autodetected
@@ -179,13 +208,15 @@ const standardColumns = _.mapValues({
  * invisible.
  * @param autodetected - list of automatically detected columns by Tabulator
  * @param {string} recordClass - the value of BIBLIOGRAPHICAL or BIOGRAPHICAL
+ * @param {string} type - the kind of record list: "catalog" or "collection"
  */
-export function adjustDefinitions(autodetected, recordClass) {
+export function adjustDefinitions(autodetected, recordClass, type) {
     const customizedColumns = standardColumns[recordClass].clone();
     _.each(autodetected, autoColumn => {
         if (!(autoColumn.field in columnProperties)) return;
         const customColumn = customizedColumns.get(autoColumn.field);
         customColumn && customColumn.set('visible', true);
     });
+    customizedColumns.add(getAdditionalColumns(type));
     return customizedColumns.toJSON();
 }


### PR DESCRIPTION
Close #306.

In the current implementation, all annotations are loaded one by one, which is inefficient. However, loading all annotations at once requires some design choices that I would like to discuss before starting work on them, and in the meantime I would like to work on some other issues. @jgonggrijp: if you think that we can better fix loading all annotations at once before merging this, I understand.

Also close #341 (add "original catalogue" column).