### PR TITLE
Maximize loading of additional records where applicable and prevent submitting empty queries

### DIFF
--- a/backend/catalogs/api.py
+++ b/backend/catalogs/api.py
@@ -98,6 +98,8 @@ class CatalogsView(RDFView):
         "name": "schema:name",
         "description": "schema:description",
         "identifier": "schema:identifier",
+        "maximumRecordsPerPage": "edpoprec:maximumRecordsPerPage",
+        "allowEmptyQuery": "edpoprec:allowEmptyQuery",
     }
 
     def get_graph(self, request: views.Request, **kwargs) -> Graph:

--- a/backend/catalogs/graphs.py
+++ b/backend/catalogs/graphs.py
@@ -153,7 +153,7 @@ class SearchGraphBuilder:
     def _get_partial_results(self) -> list[Record]:
         start = self._start
         end = min(self._end, self.reader.number_of_results)
-        results = [self.reader.records[x] for x in range(start, end)]
+        results = [self.reader.records[x] for x in range(start, end) if x in self.reader.records]
         return results  # type: ignore
 
     def _get_content_graph(self) -> Graph:

--- a/backend/catalogs/graphs.py
+++ b/backend/catalogs/graphs.py
@@ -153,6 +153,7 @@ class SearchGraphBuilder:
     def _get_partial_results(self) -> list[Record]:
         start = self._start
         end = min(self._end, self.reader.number_of_results)
+        # Get all applicable records from self.reader.records. Note that this is a dict with integers as keys
         results = [self.reader.records[x] for x in range(start, end) if x in self.reader.records]
         return results  # type: ignore
 

--- a/frontend/vre/catalog/catalog.search.view.js
+++ b/frontend/vre/catalog/catalog.search.view.js
@@ -23,6 +23,7 @@ export var CatalogSearchView = CompositeView.extend({
             collection: this.collection,
             type: "catalog",
             recordClass: this.recordClass,
+            model: this.model,
         });
         this.render();
     },

--- a/frontend/vre/record/record.list.managing.view.js
+++ b/frontend/vre/record/record.list.managing.view.js
@@ -29,7 +29,7 @@ export var RecordListManagingView = CompositeView.extend({
 
     events: {
         'click .more-records': 'loadMore',
-        'click .500-more-records': 'load500More',
+        'click .many-more-records': 'loadManyMore',
         'click .download-xlsx': 'downloadXLSX',
         'click .download-csv': 'downloadCSV',
         'click .create-blank': 'createBlank',
@@ -56,12 +56,23 @@ export var RecordListManagingView = CompositeView.extend({
         // template and use the isCollection method directly from the template.
         // TODO: remove this workaround when wontache#84 is fixed.
         const isCollection = this.isCollection();
-        this.$el.html(this.template({isCollection}));
+        const requestMoreMaximum = this.requestMoreMaximum();
+        this.$el.html(this.template({isCollection, requestMoreMaximum}));
         return this;
     },
 
     isCollection: function() {
         return this.type === 'collection';
+    },
+
+    requestMoreMaximum: function() {
+        var maximumForCatalogue = this.model.get('maximumRecordsPerPage');
+        var maximum = 500;
+        if (maximumForCatalogue && maximumForCatalogue < maximum) {
+            return maximumForCatalogue;
+        } else {
+            return maximum;
+        }
     },
 
     submitToCollections: function() {
@@ -85,8 +96,8 @@ export var RecordListManagingView = CompositeView.extend({
         this.collection.trigger('moreRequested', event, 50);
     },
 
-    load500More: function(event) {
-        this.collection.trigger('moreRequested', event, 500);
+    loadManyMore: function(event) {
+        this.collection.trigger('moreRequested', event, this.requestMoreMaximum());
     },
 
     downloadXLSX: function() {

--- a/frontend/vre/record/record.list.managing.view.mustache
+++ b/frontend/vre/record/record.list.managing.view.mustache
@@ -2,7 +2,7 @@
 <ul class="inline-list">
 {{^isCollection}}
     <li><a href="#" class="more-records">Load 50 more records</a></li>
-    <li><a href="#" class="500-more-records">Load 500 more records</a></li>
+    <li><a href="#" class="many-more-records">Load {{requestMoreMaximum}} more records</a></li>
 {{/isCollection}}
     <li><a href="#" class="download-xlsx">Download XLSX</a></li>
     <li><a href="#" class="download-csv">Download CSV</a></li>

--- a/frontend/vre/search/search.view.js
+++ b/frontend/vre/search/search.view.js
@@ -15,7 +15,6 @@ export var SearchView = CompositeView.extend({
         method: 'prepend',
     }],
     initialize: function() {
-        this.allowEmptyQuery = this.model.get('allowEmptyQuery');
         this.render().listenTo(this.collection, {
             moreRequested: this.nextSearch,
         });

--- a/frontend/vre/search/search.view.js
+++ b/frontend/vre/search/search.view.js
@@ -101,8 +101,7 @@ export var SearchView = CompositeView.extend({
         this.queryChanged();
     },
     queryChanged: function(event) {
-        var value = event.target.value;
-        if (value.trim().length > 0 || this.model.get('allowEmptyQuery')) {
+        if (event.target.value.trim().length > 0 || this.model.get('allowEmptyQuery')) {
             this.$('#query-submit').prop('disabled', false);
         } else {
             this.$('#query-submit').prop('disabled', true);

--- a/frontend/vre/search/search.view.js
+++ b/frontend/vre/search/search.view.js
@@ -8,18 +8,20 @@ export var SearchView = CompositeView.extend({
     template: searchViewTemplate,
     events: {
         'submit': 'firstSearch',
+        'input #query-input': 'queryChanged',
     },
     subviews: [{
         view: 'alert',
         method: 'prepend',
     }],
     initialize: function() {
+        this.allowEmptyQuery = this.model.get('allowEmptyQuery');
         this.render().listenTo(this.collection, {
             moreRequested: this.nextSearch,
         });
     },
     renderContainer: function() {
-        this.$el.html(this.template());
+        this.$el.html(this.template(this.model.toJSON()));
         return this;
     },
     showPending: function() {
@@ -96,5 +98,14 @@ export var SearchView = CompositeView.extend({
     },
     fill: function(fillText) {
         this.$('#query-input').val(fillText);
+        this.queryChanged();
+    },
+    queryChanged: function(event) {
+        var value = event.target.value;
+        if (value.trim().length > 0 || this.model.get('allowEmptyQuery')) {
+            this.$('#query-submit').prop('disabled', false);
+        } else {
+            this.$('#query-submit').prop('disabled', true);
+        }
     },
 });

--- a/frontend/vre/search/search.view.mustache
+++ b/frontend/vre/search/search.view.mustache
@@ -1,7 +1,7 @@
 <form id="search">
     <div class="input-group">
         <input type="text" class="form-control" name="search" id="query-input" placeholder="Query">
-        <button type="submit" id="query-submit" class="btn btn-primary">Search</button>
+        <button type="submit" id="query-submit" {{^allowEmptyQuery}}disabled{{/allowEmptyQuery}} class="btn btn-primary">Search</button>
         <button
             type="button"
             class="btn btn-default"


### PR DESCRIPTION
To be reviewed alongside with https://github.com/CentreForDigitalHumanities/edpop-explorer/pull/98.

This PR fixes #298 (loading 500 more records was not possible for ESTC and STCN), as well as #333 (grey out "Search" button if query field is empty, except if the reader supports this). Both issues required changes in the Explorer.