### PR TITLE
Add annotations field to hardcoded copy of record ontology in frontend

### DIFF
--- a/frontend/vre/edpop-record-ontology.json
+++ b/frontend/vre/edpop-record-ontology.json
@@ -704,6 +704,21 @@
       }
     },
     {
+      "@id": "edpoprec:annotations",
+      "@type": "rdf:Property",
+      "rdfs:domain": {
+        "@id": "edpoprec:BibliographicalRecord"
+      },
+      "rdfs:range": {
+        "@id": "edpoprec:Field"
+      },
+      "skos:description": "Annotations that were made on the described item",
+      "skos:prefLabel": {
+        "@language": "en",
+        "@value": "Annotations"
+      }
+    },
+    {
       "@id": "edpoprec:dating",
       "@type": "rdf:Property",
       "rdfs:domain": {


### PR DESCRIPTION
Parallel to https://github.com/CentreForDigitalHumanities/edpop-record-ontology/pull/10, I have copy-pasted the JSON-LD description of the new field to the hardcoded copy of the record ontology in the VRE frontend. This seemed the fastest way to ensure that Jeroen could start adding annotations, rather than going out of my way to fully address #351 first.

The only code change is a JSON-LD duplicate of https://github.com/CentreForDigitalHumanities/edpop-record-ontology/pull/10, so this is probably not interesting to review. However, please do think along with me: is this really enough to ensure that Jeroen can annotate? I think it is but I might be mistaken!